### PR TITLE
Exploration of methods/forms

### DIFF
--- a/content/methods.md
+++ b/content/methods.md
@@ -108,7 +108,7 @@ myMethod.getValidationErrorsForField("name", "Hello");
 {
   name: {
     value: "Hello",
-    type: "Must be a String", // How do we avoid hardcoding messages?
+    type: true, // Let's not hardcode error messages...
   }
 }
 
@@ -127,3 +127,9 @@ myMethod.call({
 3. Saving intermediate inputs... you could have a per-user collection and have each form have a unique ID; then you have a `submit` button that actually runs the method validation?
 4. Does this help for uploading files at all?
 5. What if you want to do different validation on the client and server? I guess the validation data is only stuff that is shared between client and server...
+
+The ideal solution for forms would probably have a couple components:
+
+1. A form generator
+2. A form reader - parse the form and get an object that can be validated, reactively when user input happens; so that we can display realtime errors or save the user's progress
+3. The validating method infrastructure above

--- a/content/methods.md
+++ b/content/methods.md
@@ -120,6 +120,12 @@ myMethod.call({
   // there is a client side error it is never called on the server
   // Validation error has the data structure above attached
 });
+
+// Available on the server only
+myMethod.callWithUserId(userId, {
+  name: "Hello",
+  content: "Stuff"
+}, callback);
 ```
 
 1. Definitely solves client-side realtime validation via `getValidationErrors` - and you can do it per-field if you need to

--- a/content/methods.md
+++ b/content/methods.md
@@ -1,0 +1,129 @@
+# Forms, user input, and methods
+
+One of the hallmarks of an "app" compared to a "website" is that apps are built around user input, interaction, and collaboration. One of Meteor's best features is a great building block for user inputs: the Meteor method.
+
+The methods in your Meteor app describe the surface area of all inputs and database changes your app will accept. Think of it as enabling the create, update, and delete API of a typical REST backend, but with some extra features to enable a great user experience for your users.
+
+## Defining a method with optimistic UI and validation
+
+Several features are crucial to make your app feel modern and user-friendly.
+
+1. **Optimistic UI**: When appropriate, the user interface should respond immediately. For example, in a chat app, you would want the chat message to show up immediately to give the user feedback on their action. However, this is not always appropriate - for example, you wouldn't want to do the same for a bank transaction; the appropriate response there would be to show a processing screen until the transaction is confirmed.
+1. **Instant input validation**: Users should get immediate feedback about their inputs. They should never end up in a situation where they spent 10 minutes filling out a form only to get an error message - it should be clear what the form expects and feedback should be instant.
+
+You have probably written several methods before, especially if you've completed the Meteor getting started tutorial. Now let's go over how to make a simple method that enables the features above.
+
+### Reality
+
+```js
+Meteor.methods({
+  // XXX method naming?
+  "/widgets/new"() {
+
+  }
+});
+```
+
+XXX call with throwStubExceptions :[
+
+```js
+try {
+  Meteor.call("/widgets/new", {
+    throwStubExceptions: true
+  }, (err, res) => {
+    if (err) {
+      // Handler server-side error
+    } else {
+      // Success!
+    }
+  });
+} catch (validationError) {
+  // Handle client-side validation error
+}
+```
+
+### Pseudocode below
+
+```js
+// Defining validated method
+const myMethod = Methods.define({
+  // Name needs to be unique? can we get around this
+  // Actually if you want to be able to call this method from a native
+  // app or something, it needs a well-defined global name.
+  name: "/widgets/new",
+
+  // All args are keyword args
+  // Also, note that schema is only the stuff that the client knows how
+  // to validate; you might need to add additional server-side validation
+  // logic in the server-side implementation.
+  schema: {
+    name: {
+      type: String,
+      required: true,
+      maxLength: 10,
+      isNotFive: (val) => {
+        if (val === '5') {
+          // I would like to not have UI strings here
+          return "Value is 5";
+        }
+      }
+      // ...
+    },
+    content: {
+      type: String,
+      maxLength: 500,
+      // ...
+    }
+  },
+
+  // Can also be split into simulation() and server() or something?
+  run({name, content}) {
+    Widgets.insert({
+      name,
+      content,
+      createdAt: new Date()
+    });
+  }
+});
+```
+
+```js
+// Or, you can just `require` the original object?
+const myMethod = Methods.getMethod("/widgets/new");
+
+// Usage
+myMethod.getValidationErrors({
+  name: "Hello",
+  content: "Stuff"
+});
+
+// For a specific field
+myMethod.getValidationErrorsForField("name", "Hello");
+
+// Returns `null` if there are no errors, so you can do
+// const errors = myMethod.getValidationErrors(args);
+// if (! errors) { ... }
+
+// If there are errors, returns JS object of a form similar to
+{
+  name: {
+    value: "Hello",
+    type: "Must be a String", // How do we avoid hardcoding messages?
+  }
+}
+
+myMethod.call({
+  name: "Hello",
+  content: "Stuff"
+}, (err, res) => {
+  // Get the `err` result here even if it's a client-side error, and if
+  // there is a client side error it is never called on the server
+  // Validation error has the data structure above attached
+});
+```
+
+1. Definitely solves client-side realtime validation via `getValidationErrors` - and you can do it per-field if you need to
+2. You could auto-generate forms via the `schema` property
+3. Saving intermediate inputs... you could have a per-user collection and have each form have a unique ID; then you have a `submit` button that actually runs the method validation?
+4. Does this help for uploading files at all?
+5. What if you want to do different validation on the client and server? I guess the validation data is only stuff that is shared between client and server...

--- a/content/methods.md
+++ b/content/methods.md
@@ -134,6 +134,10 @@ myMethod.callWithUserId(userId, {
 4. Does this help for uploading files at all?
 5. What if you want to do different validation on the client and server? I guess the validation data is only stuff that is shared between client and server...
 
+Questions
+
+1. Should this return a promise?? We've been waiting for a chance to integrate async/await - this could be that opportunity!
+
 The ideal solution for forms would probably have a couple components:
 
 1. A form generator

--- a/content/routing.md
+++ b/content/routing.md
@@ -57,15 +57,19 @@ FlowRouter.route('/blog/:postId', {
 
 This route handler will run in two situations: if the page loads initially at a URL that matches the URL pattern, and if the URL changes to one that matches the pattern while the page is open. Note that, unlike in a server-side-rendered app, the URL can change without any additional requests to the server.
 
-When the route is matched, the `action` method executes, and you can perform any actions you need to.
-
-The `name` property of the route is optional, but will let us refer to this route more conveniently later on.
+When the route is matched, the `action` method executes, and you can perform any actions you need to. The `name` property of the route is optional, but will let us refer to this route more conveniently later on.
 
 ### URL pattern matching
 
-The above code snippet will match certain URLs. You may notice that one of the segments is prefixed by `:` - this means that it is a *url parameter*, and will match any string that is present in that segment of the path. Here are some example URLs and the resulting `pathParams` and `queryParams`:
+Consider the following URL pattern, used in the code snippet above:
 
-| URL           | action() called?	        | pathParams	         | queryParams
+```js
+'/blog/:postId'
+```
+
+The above pattern will match certain URLs. You may notice that one of the segments is prefixed by `:` - this means that it is a *url parameter*, and will match any string that is present in that segment of the path. Here are some example URLs and the resulting `pathParams` and `queryParams`:
+
+| URL           | matches pattern? | pathParams	         | queryParams
 | ---- | ---- | ---- | ---- |
 | /	            | no		
 | /about	      | no		

--- a/outlines.md
+++ b/outlines.md
@@ -64,6 +64,7 @@ Meteor's login system works pretty well out of the box, but there are a few tips
 1. Picking an accounts UI package
 2. Setting up password reset, email verification, and enrollment emails
 3. Setting up OAuth login services
+4. Building your own login service
 4. Adding custom fields to the users collection and using them
 
 ### Meteor guide: Security


### PR DESCRIPTION
Not even close to ready at all

@tmeasday please edit
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/meteor/guide/pull/27%23issuecomment-147578987%22%2C%20%22https%3A//github.com/meteor/guide/pull/27%23issuecomment-147580135%22%2C%20%22https%3A//github.com/meteor/guide/pull/27%23issuecomment-147589554%22%2C%20%22https%3A//github.com/meteor/guide/pull/27%23issuecomment-147598204%22%2C%20%22https%3A//github.com/meteor/guide/pull/27%23issuecomment-147599939%22%2C%20%22https%3A//github.com/meteor/guide/pull/27%23issuecomment-147600211%22%2C%20%22https%3A//github.com/meteor/guide/pull/27%23issuecomment-147780885%22%2C%20%22https%3A//github.com/meteor/guide/pull/27%23issuecomment-150654714%22%2C%20%22https%3A//github.com/meteor/guide/pull/27%23issuecomment-150656039%22%2C%20%22https%3A//github.com/meteor/guide/pull/27%23issuecomment-150666057%22%2C%20%22https%3A//github.com/meteor/guide/pull/27%23issuecomment-150678559%22%2C%20%22https%3A//github.com/meteor/guide/pull/27%23issuecomment-150696842%22%2C%20%22https%3A//github.com/meteor/guide/pull/27%23issuecomment-150761148%22%2C%20%22https%3A//github.com/meteor/guide/pull/27%23issuecomment-150832373%22%2C%20%22https%3A//github.com/meteor/guide/pull/27%23issuecomment-150920188%22%2C%20%22https%3A//github.com/meteor/guide/pull/27%23issuecomment-150979932%22%2C%20%22https%3A//github.com/meteor/guide/pull/27%23issuecomment-161461538%22%2C%20%22https%3A//github.com/meteor/guide/pull/27%23issuecomment-161467825%22%2C%20%22https%3A//github.com/meteor/guide/pull/27%23issuecomment-161505271%22%2C%20%22https%3A//github.com/meteor/guide/pull/27%23issuecomment-161506876%22%2C%20%22https%3A//github.com/meteor/guide/pull/27%23issuecomment-161717445%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/27%23issuecomment-147578987%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22What%20about%20%5Btwo-tiered%20methods%5D%28https%3A//www.discovermeteor.com/blog/meteor-pattern-two-tiered-methods/%29%3F%22%2C%20%22created_at%22%3A%20%222015-10-13T02%3A39%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/358832%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/SachaG%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yep%2C%20I%27ve%20read%20that%20one%2C%20and%20it%20mirrors%20my%20own%20experiences%20with%20methods.%5Cr%5Cn%5Cr%5Cn%60%7B%7B%3E%20quickForm%20collection%3D%5C%22Posts%5C%22%20id%3D%5C%22submitPostForm%5C%22%20template%3D%5C%22telescope%5C%22%20%5Cr%5Cn%20%20type%3D%5C%22method%5C%22%20meteormethod%3D%5C%22submitPost%5C%22%7D%7D%60%5Cr%5Cn%5Cr%5CnThis%20could%20be%20a%20reasonable%20way%20to%20generate%20the%20form%2C%20although%20it%20feels%20like%20AutoForm%20does%20way%20too%20much%20stuff%2C%20and%20encourages%20you%20to%20have%20the%20same%20schema%20for%20your%20form%20as%20for%20the%20collection.%20But%20given%20how%20many%20packages%20are%20available%20for%20autoform%2C%20it%20might%20not%20be%20an%20option%20to%20not%20use%20it.%5Cr%5Cn%5Cr%5CnI%27ve%20also%20run%20into%20the%20situation%20of%20wanting%20to%20call%20methods%20while%20pretending%20to%20be%20a%20different%20user.%20I%20feel%20like%20the%20solution%20here%20is%20to%20somehow%20build%20that%20into%20the%20%27standard%27%20method%20infrastructure.%20Personally%20I%20hated%20having%20two%20copies%20of%20every%20single%20method%20in%20my%20app%2C%20it%20just%20made%20it%20a%20nightmare%20to%20change%20any%20arguments%2C%20and%20having%20that%20kind%20of%20code%20duplication%20in%20general%20leads%20to%20copy-paste%20errors%20and%20similar.%5Cr%5Cn%5Cr%5CnI%20like%20the%20idea%20of%20asynchronous%20tasks%20with%20%60Meteor.defer%60.%5Cr%5Cn%5Cr%5CnI%20guess%20my%20idea%20is%20to%20split%20out%20the%20client-side%20validation%20and%20security%20into%20defined%20properties%20of%20the%20method%2C%20rather%20than%20having%20two%20functions%20where%20one%20wraps%20the%20other%2C%20and%20just%20having%20a%20first-class%20way%20to%20call%20the%20validation%2C%20security%2C%20etc%20separately.%5Cr%5Cn%5Cr%5Cn%23%23%23%20TL%3BDR%5Cr%5Cn%5Cr%5CnI%20think%20it%20would%20be%20great%20if%20the%20%5C%22normal%5C%22%20way%20to%20call%20methods%20supported%20these%20features%20directly%20rather%20than%20needing%20to%20split%20into%20two%20functions.%22%2C%20%22created_at%22%3A%20%222015-10-13T02%3A49%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40SachaG%20what%20happens%20if%20one%20of%20the%20deferred%20callbacks%20fails%3F%20Seems%20like%20you%20could%20easily%20end%20up%20with%20an%20incorrect%20count%20somewhere%20if%20your%20server%20disconnects%20from%20the%20database%20momentarily%2C%20or%20the%20container%20spins%20down%2C%20or%20your%20code%20is%20wrong%20in%20some%20edge%20case%2C%20etc.%20I%20was%20drawing%20a%20flow%20chart%20for%20how%20errors%20get%20handled%20and%20I%20don%27t%20know%20what%20would%20happen%20with%20an%20error%20in%20that%20case.%20I%20guess%20it%20would%20get%20printed%20in%20the%20logs%20and%20the%20data%20would%20just%20be%20incorrect%20from%20then%20on.%20But%20maybe%20that%27s%20unavoidable%20with%20any%20denormalized%20schema%3F%22%2C%20%22created_at%22%3A%20%222015-10-13T03%3A51%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22Here%27s%20the%20closest%20I%20could%20get%20with%20AutoForm%3A%20https%3A//github.com/stubailo/meteor-validating-method-form-example/blob/master/meteor-validating-method-form-example.js%5Cr%5Cn%5Cr%5CnMy%20main%20gripe%20is%20that%20the%20forms%20are%20global%2C%20so%20it%20is%20weird%20to%20set%20up%20template-local%20hooks.%20Like%20if%20I%20wanted%20to%20generate%20a%20unique%20ID%20for%20each%20new%20form%20so%20that%20I%20could%20have%20two%20on%20one%20page%2C%20then%20I%27d%20end%20up%20with%20a%20potentially%20infinite%20amount%20of%20hooks%3F%22%2C%20%22created_at%22%3A%20%222015-10-13T04%3A22%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40stubailo%20yeah%2C%20in%20Telescope%20at%20least%20deferred%20callbacks%20can%20fail%20silently.%20But%20they%20usually%20handle%20things%20that%20can%20fail%20without%20causing%20any%20problems%2C%20like%20updating%20scores%2C%20counts%2C%20etc.%20%5Cr%5Cn%5Cr%5CnI%27m%20not%20sure%20about%20the%20hooks%20thing%20though.%20Maybe%20we%20should%20get%20%40aldeed%20in%20here%3F%22%2C%20%22created_at%22%3A%20%222015-10-13T04%3A43%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/358832%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/SachaG%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yeah%2C%20it%20seems%20like%20a%20really%20common%20thing%20to%20get%20an%20error%20from%20a%20server-side%20method%2C%20I%20would%20expect%20there%20is%20probably%20some%20smoother%20way%20to%20handle%20it.%22%2C%20%22created_at%22%3A%20%222015-10-13T04%3A46%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22OK%20for%20notes%2C%20things%20I%27m%20trying%20to%20find%20out%20how%20to%20do%20in%20autoform%3A%5Cr%5Cn%5Cr%5Cn1.%20Have%20independent%20forms%20for%20the%20same%20method%20-%20so%20the%20method%20they%20call%20is%20the%20same%20method%2C%20but%20the%20inputs%20are%20saved%20independently%2C%20and%20the%20inputs%20have%20different%20IDs%5Cr%5Cn2.%20Have%20inputs%20in%20a%20form%20persist%20across%20page%20reloads%2C%20while%20still%20having%20a%20submit%20button%20%28like%20in%20Asana%20and%20GitHub%29%5Cr%5Cn3.%20Show%20a%20loading%20indicator%20while%20a%20method%20is%20being%20processed%2C%20in%20cases%20where%20optimistic%20UI%20is%20not%20appropriate%5Cr%5Cn%5Cr%5CnIt%20looks%20like%20a%20lot%20of%20these%20could%20be%20done%20using%20hooks%2C%20but%20I%20don%27t%20know%20how%20hooks%20interact%20with%20%281%29.%22%2C%20%22created_at%22%3A%20%222015-10-13T17%3A11%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40stubailo%20%5Cr%5Cn%5Cr%5Cn1.%20Not%20sure%20about%20the%20exact%20use%20case%20here%2C%20but%20if%20there%20are%20multiple%20update%20forms%20pointing%20to%20the%20same%20method%2C%20the%20method%20would%20receive%20just%20the%20%60%24set/%24unset%60%20modifier%20for%20whatever%20fields%20are%20on%20that%20form.%20So%20then%20the%20method%20just%20needs%20to%20check%20role%20security%2C%20%60ss.clean%28modifier%29%60%20and%20%60check%28modifier%2C%20ss%29%60%20%28if%20schema%20isn%27t%20already%20attached%20to%20the%20collection%20with%20collection2%29%2C%20and%20then%20%60collection.update%28id%2C%20modifier%29%60.%5Cr%5Cn2.%20I%20assume%20you%27re%20referring%20to%20%5C%22non-hot%5C%22%20reloads%3F%20%3A%29%20It%20should%20be%20possible%20to%20tap%20into%20the%20window%20location%20change%20event%20and%20persist%20in%20localstorage%20exactly%20like%20it%20does%20for%20hot%20reload%20already%2C%20but%20we%27d%20need%20some%20way%20for%20forms%20to%20opt%20into%20that.%5Cr%5Cn3.%20This%20should%20already%20be%20the%20case.%20%60beginSumit%60%20and%20%60endSubmit%60%20are%20where%20loading%20indicators%20should%20be%20started%20and%20stopped%2C%20and%20%60endSubmit%60%20is%20not%20called%20until%20the%20method%20callback%20is%20called.%22%2C%20%22created_at%22%3A%20%222015-10-23T18%3A24%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3012067%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aldeed%22%7D%7D%2C%20%7B%22body%22%3A%20%22Oh%2C%20and%20regarding%20global%20scope%2C%20this%20has%20bothered%20me%20pretty%20much%20since%20the%20beginning%2C%20but%20since%20forms%20and%20their%20field%20values%20need%20to%20be%20referenced%20in%20various%20templates%2C%20the%20unique%20id%20requirement%20seems%20necessary.%5Cr%5Cn%5Cr%5CnCurrently%20the%20best%20way%20to%20manage%20hooks%20in%20complex%20situations%20is%20to%20do%20this%20%28from%20readme%29%3A%5Cr%5Cn%5Cr%5Cn%60%60%60%5Cr%5Cn//%20Or%20pass%20%60null%60%20to%20run%20the%20hook%20for%20all%20forms%20in%20the%20app%20%28global%20hook%29%5Cr%5CnAutoForm.addHooks%28null%2C%20hooksObject%29%3B%5Cr%5Cn%60%60%60%5Cr%5Cn%5Cr%5CnAnd%20then%20do%20regex%20matching%20on%20the%20form%20ID%20to%20determine%20which%20form%20or%20group%20of%20forms%20it%20is.%5Cr%5Cn%5Cr%5CnAllowing%20regex%20directly%20as%20the%20first%20arg%20of%20%60addHooks%60%20has%20been%20proposed%20but%20isn%27t%20done%20as%20far%20as%20I%20remember.%22%2C%20%22created_at%22%3A%20%222015-10-23T18%3A28%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3012067%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aldeed%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3E%20since%20forms%20and%20their%20field%20values%20need%20to%20be%20referenced%20in%20various%20templates%5Cr%5Cn%5Cr%5CnWhat%20do%20you%20mean%20by%20this%3F%20Would%20it%20be%20covered%20by%20passing%20around%20a%20reference%20to%20the%20form%20object%20when%20you%20need%20to%2C%20rather%20than%20having%20it%20be%20global%3F%22%2C%20%22created_at%22%3A%20%222015-10-23T19%3A09%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40stubailo%3A%20Yes%2C%20if%20there%20were%20a%20form%20object.%20But%20there%20isn%27t%20really%20any%20such%20thing%20right%20now.%20There%20are%20just%20blaze%20templates%20and%20various%20helpers%20that%20rerun%2C%20looking%20up%20the%20view%20tree%20and%20into%20the%20schema%20for%20whatever%20data%20or%20options%20they%20need.%20So%20the%20%60autoForm%60%20template%20instance%20is%20the%20closest%20thing%20to%20a%20form%20object.%20I%20did%20it%20that%20way%20intentionally%20to%20support%20easy%20no-coding%20forms%2C%20but%20maybe%20there%20could%20be%20some%20middle%20ground.%22%2C%20%22created_at%22%3A%20%222015-10-23T20%3A13%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3012067%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aldeed%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3E%20Yes%2C%20if%20there%20were%20a%20form%20object.%20But%20there%20isn%27t%20really%20any%20such%20thing%20right%20now.%5Cr%5Cn%5Cr%5CnIt%20seems%20like%20if%20the%20helpers/event%20handlers/state%20on%20the%20form%20could%20be%20refactored%20in%20a%20separate%20object%20that%20can%20be%20retrieved%20from%20the%20template%2C%20that%20would%20be%20pretty%20great%2C%20and%20would%20be%20a%20good%20step%20towards%20a%20view-engine-agnostic%20library.%22%2C%20%22created_at%22%3A%20%222015-10-23T21%3A26%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40stubailo%20what%20do%20you%20think%20about%20an%20option%20on%20%60ReactiveDict%60%5B1%5D%20to%20serialize%20to%20localstorage%20all%20the%20time%20rather%20than%20just%20on%20HCR%3F%20Could%20this%20make%20your%20form%20saving%20dream%20trivial%20%5B2%5D%3F%5Cr%5Cn%5Cr%5Cn%5B1%5D%20Or%20a%20local%20collection%20I%20guess.%5Cr%5Cn%5B2%5D%20Assuming%20forms%20were%20backed%20by%20%60ReactiveDict%60s%20of%20course.%22%2C%20%22created_at%22%3A%20%222015-10-24T06%3A01%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40tmeasday%20yes%2C%20that%20would%20probably%20work%20fine%21%20Although%2C%20there%20is%20also%20a%20question%20of%20whether%20we%20should%20just%20save%20the%20intermediate%20form%20result%20to%20the%20database%20so%20that%20you%20can%20also%20access%20it%20from%20other%20clients%20-%20but%20perhaps%20that%20is%20too%20fancy%20and%20isn%27t%20the%20best%20experience%20for%20every%20app.%20Although%20that%20is%20what%20Asana%20does%20for%20example.%22%2C%20%22created_at%22%3A%20%222015-10-24T16%3A40%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22Could%20be%20both%20options%3A%20%60onLeavePage%3A%20%27cache%27%20%7C%20%27save%27%60%22%2C%20%22created_at%22%3A%20%222015-10-25T12%3A48%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3012067%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aldeed%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20idea%20of%20persisting%20it%20makes%20it%20feel%20like%20it%27d%20be%20simplest%20to%20use%20a%20%60Mongo.Collection%60%20in%20all%20cases.%20Local%20collections%20should%20really%20have%20support%20for%20HCP%20resuming%20huh.%22%2C%20%22created_at%22%3A%20%222015-10-25T22%3A19%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20think%20the%20new%20plan%20for%20this%20is%20to%20split%20up%20Methods%20and%20Forms%20into%20two%20articles%2C%20and%20do%20Methods%20first.%20This%20way%2C%20the%20Method%20article%20won%27t%20be%20coupled%20with%20Blaze%2C%20and%20can%20teach%20people%20how%20to%20use%20validation%20errors%2C%20etc.%5Cr%5Cn%5Cr%5CnForms%20have%20a%20couple%20of%20outstanding%20questions%2C%20and%20we%20don%27t%20have%20an%20example%20app%20to%20play%20around%20with%20ideas%2C%20so%20it%20might%20take%20a%20lot%20longer%20to%20build.%20%40aldeed%20do%20you%20know%20of%20any%20simple-ish%20example%20app%20with%20a%20lot%20of%20forms%20that%20we%20could%20adopt%3F%20Unfortunately%20Todos%2C%20Microscope%2C%20etc.%20don%27t%20have%20many%20forms%20at%20all%20so%20they%20aren%27t%20great%20at%20demonstrating%20the%20concepts%20around%20form%20validation%20that%20we%20need%20to%20figure%20out.%22%2C%20%22created_at%22%3A%20%222015-12-02T23%3A03%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40stubailo%20Telescope%3F%22%2C%20%22created_at%22%3A%20%222015-12-02T23%3A37%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/358832%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/SachaG%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40SachaG%20I%20think%20telescope%20is%20way%20to%20large%20a%20scope%20for%20us%20to%20look%20at%20rewriting.%20%5Cr%5Cn%5Cr%5CnMicroscope%20would%20be%20big%2C%20but%20doable%20%28I%20mean%20we%20are%20going%20to%20do%20it%20anyway%2C%20right%3F%29%20but%20I%20just%20don%27t%20think%20it%20has%20enough%20forms%20to%20really%20test%20stuff%20out%20properly.%22%2C%20%22created_at%22%3A%20%222015-12-03T03%3A27%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22Oh%20sorry%2C%20I%20thought%20you%20were%20just%20looking%20for%20use%20cases%20to%20look%20at.%20Yeah%2C%20rewriting%20Telescope%20would%20be%20a%20big%20thing.%20%5Cr%5Cn%5Cr%5CnWe%20could%20always%20add%20more%20forms%20to%20Microscope%20though%20%3A%29%22%2C%20%22created_at%22%3A%20%222015-12-03T03%3A43%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/358832%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/SachaG%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20can%27t%20think%20of%20one%20offhand.%5Cr%5Cn%5Cr%5CnI%20think%20the%20forms%20example%20should%20include%20a%20modern%20wizardy%20form%2C%20with%20sections%20that%20slide%20in%20and%20out%2C%20back/forward%20buttons%2C%20etc.%20I%20get%20a%20LOT%20of%20questions%20about%20how%20to%20adapt%20autoforms%20to%20do%20that.%20The%20truth%20is%20that%20outside%20of%20admin%20CRUD%2C%20most%20forms%20these%20days%20are%20not%20a%20straightforward%20block%20of%20fields%20with%20a%20submit%20button.%20People%20ask%20about%20showing/hiding%20sections%2C%20autosaving%2C%20and%20if%20you%20autosave%2C%20what%20about%20optionality/requiredness%20of%20remaining%20fields%2C%20piecemeal%20validation%2C%20etc.%3F%20Not%20that%20this%20is%20all%20in%20scope%20for%20the%20guide%2C%20but%20it%20does%20relate%20to%20how/when%20you%20call%20methods%20and%20perform%20validation.%22%2C%20%22created_at%22%3A%20%222015-12-03T17%3A05%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3012067%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aldeed%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/27#issuecomment-147578987'>General Comment</a></b>
- <a href='https://github.com/SachaG'><img border=0 src='https://avatars.githubusercontent.com/u/358832?v=3' height=16 width=16'></a> What about [two-tiered methods](https://www.discovermeteor.com/blog/meteor-pattern-two-tiered-methods/)?
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Yep, I've read that one, and it mirrors my own experiences with methods.
`{{> quickForm collection="Posts" id="submitPostForm" template="telescope"
type="method" meteormethod="submitPost"}}`
This could be a reasonable way to generate the form, although it feels like AutoForm does way too much stuff, and encourages you to have the same schema for your form as for the collection. But given how many packages are available for autoform, it might not be an option to not use it.
I've also run into the situation of wanting to call methods while pretending to be a different user. I feel like the solution here is to somehow build that into the 'standard' method infrastructure. Personally I hated having two copies of every single method in my app, it just made it a nightmare to change any arguments, and having that kind of code duplication in general leads to copy-paste errors and similar.
I like the idea of asynchronous tasks with `Meteor.defer`.
I guess my idea is to split out the client-side validation and security into defined properties of the method, rather than having two functions where one wraps the other, and just having a first-class way to call the validation, security, etc separately.
### TL;DR
I think it would be great if the "normal" way to call methods supported these features directly rather than needing to split into two functions.
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> @SachaG what happens if one of the deferred callbacks fails? Seems like you could easily end up with an incorrect count somewhere if your server disconnects from the database momentarily, or the container spins down, or your code is wrong in some edge case, etc. I was drawing a flow chart for how errors get handled and I don't know what would happen with an error in that case. I guess it would get printed in the logs and the data would just be incorrect from then on. But maybe that's unavoidable with any denormalized schema?
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Here's the closest I could get with AutoForm: https://github.com/stubailo/meteor-validating-method-form-example/blob/master/meteor-validating-method-form-example.js
My main gripe is that the forms are global, so it is weird to set up template-local hooks. Like if I wanted to generate a unique ID for each new form so that I could have two on one page, then I'd end up with a potentially infinite amount of hooks?
- <a href='https://github.com/SachaG'><img border=0 src='https://avatars.githubusercontent.com/u/358832?v=3' height=16 width=16'></a> @stubailo yeah, in Telescope at least deferred callbacks can fail silently. But they usually handle things that can fail without causing any problems, like updating scores, counts, etc.
I'm not sure about the hooks thing though. Maybe we should get @aldeed in here?
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Yeah, it seems like a really common thing to get an error from a server-side method, I would expect there is probably some smoother way to handle it.
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> OK for notes, things I'm trying to find out how to do in autoform:
1. Have independent forms for the same method - so the method they call is the same method, but the inputs are saved independently, and the inputs have different IDs
2. Have inputs in a form persist across page reloads, while still having a submit button (like in Asana and GitHub)
3. Show a loading indicator while a method is being processed, in cases where optimistic UI is not appropriate
It looks like a lot of these could be done using hooks, but I don't know how hooks interact with (1).
- <a href='https://github.com/aldeed'><img border=0 src='https://avatars.githubusercontent.com/u/3012067?v=3' height=16 width=16'></a> @stubailo
1. Not sure about the exact use case here, but if there are multiple update forms pointing to the same method, the method would receive just the `$set/$unset` modifier for whatever fields are on that form. So then the method just needs to check role security, `ss.clean(modifier)` and `check(modifier, ss)` (if schema isn't already attached to the collection with collection2), and then `collection.update(id, modifier)`.
2. I assume you're referring to "non-hot" reloads? :) It should be possible to tap into the window location change event and persist in localstorage exactly like it does for hot reload already, but we'd need some way for forms to opt into that.
3. This should already be the case. `beginSumit` and `endSubmit` are where loading indicators should be started and stopped, and `endSubmit` is not called until the method callback is called.
- <a href='https://github.com/aldeed'><img border=0 src='https://avatars.githubusercontent.com/u/3012067?v=3' height=16 width=16'></a> Oh, and regarding global scope, this has bothered me pretty much since the beginning, but since forms and their field values need to be referenced in various templates, the unique id requirement seems necessary.
Currently the best way to manage hooks in complex situations is to do this (from readme):
```
// Or pass `null` to run the hook for all forms in the app (global hook)
AutoForm.addHooks(null, hooksObject);
```
And then do regex matching on the form ID to determine which form or group of forms it is.
Allowing regex directly as the first arg of `addHooks` has been proposed but isn't done as far as I remember.
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> > since forms and their field values need to be referenced in various templates
What do you mean by this? Would it be covered by passing around a reference to the form object when you need to, rather than having it be global?
- <a href='https://github.com/aldeed'><img border=0 src='https://avatars.githubusercontent.com/u/3012067?v=3' height=16 width=16'></a> @stubailo: Yes, if there were a form object. But there isn't really any such thing right now. There are just blaze templates and various helpers that rerun, looking up the view tree and into the schema for whatever data or options they need. So the `autoForm` template instance is the closest thing to a form object. I did it that way intentionally to support easy no-coding forms, but maybe there could be some middle ground.
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> > Yes, if there were a form object. But there isn't really any such thing right now.
It seems like if the helpers/event handlers/state on the form could be refactored in a separate object that can be retrieved from the template, that would be pretty great, and would be a good step towards a view-engine-agnostic library.
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> @stubailo what do you think about an option on `ReactiveDict`[1] to serialize to localstorage all the time rather than just on HCR? Could this make your form saving dream trivial [2]?
[1] Or a local collection I guess.
[2] Assuming forms were backed by `ReactiveDict`s of course.
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> @tmeasday yes, that would probably work fine! Although, there is also a question of whether we should just save the intermediate form result to the database so that you can also access it from other clients - but perhaps that is too fancy and isn't the best experience for every app. Although that is what Asana does for example.
- <a href='https://github.com/aldeed'><img border=0 src='https://avatars.githubusercontent.com/u/3012067?v=3' height=16 width=16'></a> Could be both options: `onLeavePage: 'cache' | 'save'`
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> The idea of persisting it makes it feel like it'd be simplest to use a `Mongo.Collection` in all cases. Local collections should really have support for HCP resuming huh.
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> I think the new plan for this is to split up Methods and Forms into two articles, and do Methods first. This way, the Method article won't be coupled with Blaze, and can teach people how to use validation errors, etc.
Forms have a couple of outstanding questions, and we don't have an example app to play around with ideas, so it might take a lot longer to build. @aldeed do you know of any simple-ish example app with a lot of forms that we could adopt? Unfortunately Todos, Microscope, etc. don't have many forms at all so they aren't great at demonstrating the concepts around form validation that we need to figure out.
- <a href='https://github.com/SachaG'><img border=0 src='https://avatars.githubusercontent.com/u/358832?v=3' height=16 width=16'></a> @stubailo Telescope?
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> @SachaG I think telescope is way to large a scope for us to look at rewriting.
Microscope would be big, but doable (I mean we are going to do it anyway, right?) but I just don't think it has enough forms to really test stuff out properly.
- <a href='https://github.com/SachaG'><img border=0 src='https://avatars.githubusercontent.com/u/358832?v=3' height=16 width=16'></a> Oh sorry, I thought you were just looking for use cases to look at. Yeah, rewriting Telescope would be a big thing.
We could always add more forms to Microscope though :)
- <a href='https://github.com/aldeed'><img border=0 src='https://avatars.githubusercontent.com/u/3012067?v=3' height=16 width=16'></a> I can't think of one offhand.
I think the forms example should include a modern wizardy form, with sections that slide in and out, back/forward buttons, etc. I get a LOT of questions about how to adapt autoforms to do that. The truth is that outside of admin CRUD, most forms these days are not a straightforward block of fields with a submit button. People ask about showing/hiding sections, autosaving, and if you autosave, what about optionality/requiredness of remaining fields, piecemeal validation, etc.? Not that this is all in scope for the guide, but it does relate to how/when you call methods and perform validation.


<a href='https://www.codereviewhub.com/meteor/guide/pull/27?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/meteor/guide/pull/27?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/meteor/guide/pull/27'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>