### PR TITLE
Add outline for application structure article

### DIFF
--- a/outlines/structure.md
+++ b/outlines/structure.md
@@ -19,10 +19,10 @@
     6. Perhaps this should include copypasta boilerplate - a standard template/component, a standard publication, standard route, etc? Basically the stuff a scaffolding framework would generate for you?
 5. Small app
     1. Directory structure around features, not client/server
-    2. LESS/SCSS files are in the same directory as components, with a separate directory for reusable mixins, other common stuff
+    2. LESS/SCSS files are in the same directory as components
     3. One file per unit - template, method, collection, etc
     4. Each app-scoped variable is a cost to maintainability, use JS scope as much as possible to control access
-    5. XXX
+    5. There is a common directory called `imports` which has reusable JS/LESS/etc code, which can be imported from the rest of app code.
 6. Medium app
     1. Why you want to switch to this structure
         1. You're starting to have a lot of app-scoped variables

--- a/outlines/structure.md
+++ b/outlines/structure.md
@@ -1,0 +1,56 @@
+# Application structure and code style
+
+1. What's different between Meteor and other kinds of apps?
+    1. All JavaScript, enables code sharing
+    2. Structure is flexible
+    3. Currently everything is about magic file names
+    4. App scope vs. package scope vs. file scope variables
+2. Client vs. server vs. both
+3. Smooth path from prototype to production, three sizes of apps, S, M, L
+4. General stuff
+    1. Filenames - named the same as the export
+        1. Every file exports one thing
+    2. Avoid depending on load order via namespacing and Meteor.startup
+        1. If you depend on load order, your best bet is a package
+    3. Naming guidelines for everything
+        1. https://github.com/meteor/guide/issues/9#issuecomment-148800085
+    4. Templates should have a CSS class that matches the template name, and other Blaze suggestions
+    5. Meteor ES2015 style guide (link to it, don't reproduce all of it)
+    6. Perhaps this should include copypasta boilerplate - a standard template/component, a standard publication, standard route, etc? Basically the stuff a scaffolding framework would generate for you?
+5. Small app
+    1. Directory structure around features, not client/server
+    2. LESS/SCSS files are in the same directory as components, with a separate directory for reusable mixins, other common stuff
+    3. One file per unit - template, method, collection, etc
+    4. Each app-scoped variable is a cost to maintainability, use JS scope as much as possible to control access
+    5. XXX
+6. Medium app
+    1. Why you want to switch to this structure
+        1. You're starting to have a lot of app-scoped variables
+        2. Load order is getting crazy
+        3. You want smaller modules to test individually
+    2. All package app structure
+    3. app-lib package with all of your app's common dependencies
+    4. Reusable packages vs. app-specific packages
+        1. Lots of these guidelines go into the guide about building a package
+        2. Don't use the username prefix for app local packages
+    5. Grab tools from: https://forums.meteor.com/t/tools-meteor-update-testing-for-packages-for-everything/11881/7
+7. Large app
+    1. Why you want this structure
+        1. Lots of different totally separate UIs, and you want to avoid intersecting the code
+            1. Admin app
+            2. Mobile vs. desktop
+            3. Different classes of users
+        2. Independently scaled and secured services
+        3. Independent development teams
+    2. Sharing code between different apps
+        1. Local packages
+        2. Git submodules
+        3. PACKAGE_DIRS
+        4. One or many repositories
+    3. Sharing data between different apps
+        1. Through database directly
+        2. Through DDP API
+        3. Through REST API
+    4. Sharing user accounts between different apps
+        1. AccountsClient/AccountsServer
+        2. Accounts connection URL

--- a/outlines/structure.md
+++ b/outlines/structure.md
@@ -12,8 +12,7 @@
         1. Every file exports one thing
     2. Avoid depending on load order via namespacing and Meteor.startup
         1. If you depend on load order, your best bet is a package
-    3. Naming guidelines for everything
-        1. https://github.com/meteor/guide/issues/9#issuecomment-148800085
+    3. Naming guidelines for everything [see bottom]
     4. Templates should have a CSS class that matches the template name, and other Blaze suggestions
     5. Meteor ES2015 style guide (link to it, don't reproduce all of it)
     6. Perhaps this should include copypasta boilerplate - a standard template/component, a standard publication, standard route, etc? Basically the stuff a scaffolding framework would generate for you?
@@ -54,3 +53,80 @@
     4. Sharing user accounts between different apps
         1. AccountsClient/AccountsServer
         2. Accounts connection URL
+
+### Appendix: Naming guidelines
+
+#### Collections
+
+- Name is plural
+- Instance variable is capitalized camel case
+- Collection name in DB is same as the instance variable
+
+```js
+FuzzyPinkElephants = new Mongo.Collection('FuzzyPinkElephants');
+```
+
+#### Methods and publications
+
+> This part is uncertain! We should also consider dot-separated paths. You can find more details in the article/outline about Forms and Methods, where we are planning on suggesting people wrap Methods in a special object, so the actual method path can be an implementation detail.
+
+- The identifiers of methods and publications should look like URLs: slash-separated, kebab-case
+- The first part of the slash is the relevant collection name or module
+- Start with a leading slash
+- The idea is they can look like URLs and then eventually be URLs if you use a package like `simple:rest` to make them available over HTTP
+
+```js
+Meteor.methods({
+  "/fuzzy-pink-elephants/add-friends"() { ... }
+});
+```
+
+As mentioned in the #29 (forms/methods) discussion, we'd like to wrap up methods so that you call them via a module, so these names might end up being more of an implementation detail.
+
+#### Packages, files, and exports
+
+We're aware that currently not all Meteor core packages follow this pattern, but they probably should.
+
+- Packages export at most one thing
+- The export is named the same as the unprefixed package name, but capitalized and camel case
+- Every file exports at most one thing
+- The file is named exactly after the export, down to the casing
+- If a package/file is attaching its export to an existing namespace, it's OK as long as the naming convention is preserved; for example it's fine to have a namespace for all of your app-specific packages, and they attach all of their exports there to avoid polluting the global namespace.
+
+#### Templates
+
+It would make sense for templates to be namespaced via dots, like so:
+
+```html
+<template name="fuzzyPinkElephants.thumbnailGrid">
+  ...
+</template>
+```
+
+It is probably worth it to make accessing these in JS simpler:
+
+```js
+// Before
+Template['fuzzyPinkElephants.thumbnailGrid'].helpers({ ... });
+
+// After?
+Template.fuzzyPinkElephants.thumbnailGrid.helpers({ ... });
+```
+
+I imagine this would be a pretty small change to the `templating` package.
+
+In the future, I hope templates are packaged as ES2015 modules and the whole namespacing question can disappear forever.
+
+#### Everything else
+
+* kebab, split by slashes
+    * package names
+    * css classes
+    * urls
+* camel, split by dots
+    * JavaScript class names
+    * JavaScript function names
+    * template names - also namespaced by the module/collection
+    * React component names
+    * file names
+    * database fields


### PR DESCRIPTION
Please review and leave comments! This outline should represent everything that will be in the finished app structure guide.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/meteor/guide/pull/56%23discussion_r43068705%22%2C%20%22https%3A//github.com/meteor/guide/pull/56%23discussion_r43069647%22%2C%20%22https%3A//github.com/meteor/guide/pull/56%23discussion_r43088274%22%2C%20%22https%3A//github.com/meteor/guide/pull/56%23discussion_r43088464%22%2C%20%22https%3A//github.com/meteor/guide/pull/56%23discussion_r43088662%22%2C%20%22https%3A//github.com/meteor/guide/pull/56%23discussion_r43089178%22%2C%20%22https%3A//github.com/meteor/guide/pull/56%23discussion_r43089605%22%2C%20%22https%3A//github.com/meteor/guide/pull/56%23discussion_r43154070%22%2C%20%22https%3A//github.com/meteor/guide/pull/56%23discussion_r43155071%22%2C%20%22https%3A//github.com/meteor/guide/pull/56%23discussion_r43155167%22%2C%20%22https%3A//github.com/meteor/guide/pull/56%23discussion_r43159489%22%2C%20%22https%3A//github.com/meteor/guide/pull/56%23discussion_r43159736%22%2C%20%22https%3A//github.com/meteor/guide/pull/56%23discussion_r43159738%22%2C%20%22https%3A//github.com/meteor/guide/pull/56%23discussion_r43161345%22%2C%20%22https%3A//github.com/meteor/guide/pull/56%23discussion_r43161684%22%2C%20%22https%3A//github.com/meteor/guide/pull/56%23discussion_r43162283%22%2C%20%22https%3A//github.com/meteor/guide/pull/56%23discussion_r43162462%22%2C%20%22https%3A//github.com/meteor/guide/pull/56%23discussion_r43162922%22%2C%20%22https%3A//github.com/meteor/guide/pull/56%23discussion_r43165385%22%2C%20%22https%3A//github.com/meteor/guide/pull/56%23discussion_r43166039%22%2C%20%22https%3A//github.com/meteor/guide/pull/56%23discussion_r43166127%22%2C%20%22https%3A//github.com/meteor/guide/pull/56%23discussion_r43166352%22%2C%20%22https%3A//github.com/meteor/guide/pull/56%23discussion_r43166509%22%2C%20%22https%3A//github.com/meteor/guide/pull/56%23discussion_r43202546%22%2C%20%22https%3A//github.com/meteor/guide/pull/56%23discussion_r43202988%22%2C%20%22https%3A//github.com/meteor/guide/pull/56%23discussion_r43205563%22%2C%20%22https%3A//github.com/meteor/guide/pull/56%23discussion_r43206321%22%2C%20%22https%3A//github.com/meteor/guide/pull/56%23discussion_r43206610%22%2C%20%22https%3A//github.com/meteor/guide/pull/56%23discussion_r43206664%22%2C%20%22https%3A//github.com/meteor/guide/pull/56%23discussion_r43210985%22%2C%20%22https%3A//github.com/meteor/guide/pull/56%23discussion_r43211160%22%2C%20%22https%3A//github.com/meteor/guide/pull/56%23discussion_r43211506%22%2C%20%22https%3A//github.com/meteor/guide/pull/56%23discussion_r43211686%22%2C%20%22https%3A//github.com/meteor/guide/pull/56%23discussion_r43211937%22%2C%20%22https%3A//github.com/meteor/guide/pull/56%23discussion_r43212048%22%2C%20%22https%3A//github.com/meteor/guide/pull/56%23discussion_r43216744%22%2C%20%22https%3A//github.com/meteor/guide/pull/56%23discussion_r43216827%22%2C%20%22https%3A//github.com/meteor/guide/pull/56%23discussion_r43216978%22%2C%20%22https%3A//github.com/meteor/guide/pull/56%23discussion_r43216997%22%2C%20%22https%3A//github.com/meteor/guide/pull/56%23discussion_r43217165%22%2C%20%22https%3A//github.com/meteor/guide/pull/56%23discussion_r43217235%22%2C%20%22https%3A//github.com/meteor/guide/pull/56%23discussion_r43217293%22%2C%20%22https%3A//github.com/meteor/guide/pull/56%23discussion_r43217789%22%2C%20%22https%3A//github.com/meteor/guide/pull/56%23discussion_r43217943%22%2C%20%22https%3A//github.com/meteor/guide/pull/56%23discussion_r43217993%22%2C%20%22https%3A//github.com/meteor/guide/pull/56%23discussion_r43218101%22%2C%20%22https%3A//github.com/meteor/guide/pull/56%23discussion_r43347977%22%2C%20%22https%3A//github.com/meteor/guide/pull/56%23discussion_r43352466%22%2C%20%22https%3A//github.com/meteor/guide/pull/56%23discussion_r43526717%22%2C%20%22https%3A//github.com/meteor/guide/pull/56%23discussion_r43526743%22%2C%20%22https%3A//github.com/meteor/guide/pull/56%23discussion_r43527558%22%2C%20%22https%3A//github.com/meteor/guide/pull/56%23discussion_r43527583%22%2C%20%22https%3A//github.com/meteor/guide/pull/56%23discussion_r43567340%22%2C%20%22https%3A//github.com/meteor/guide/pull/56%23discussion_r43567342%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%20773091cc2645684ec5af371f1e423197d2d1f4c1%20outlines/structure.md%2022%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/56%23discussion_r43088464%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Do%20we%20recommend%20like%20a%20%60lib/%60%20or%20%60utils/%60%20directory%20for%20all%20re-usable%20stuff%20%28less%20%2B%20js%3F%29%22%2C%20%22created_at%22%3A%20%222015-10-27T06%3A43%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes%2C%20I%20think%20we%20should%20do%20that.%20I%20guess%20in%20Meteor%201.3%20it%20will%20be%20the%20%60imports%60%20directory%3F%22%2C%20%22created_at%22%3A%20%222015-10-27T17%3A25%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22Added%20mention%20of%20that.%22%2C%20%22created_at%22%3A%20%222015-10-27T17%3A52%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-10-27T17%3A53%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20outlines/structure.md%3AL1-57%22%7D%2C%20%22Pull%20773091cc2645684ec5af371f1e423197d2d1f4c1%20outlines/structure.md%2021%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/56%23discussion_r43068705%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Where%20are%20publish%20function%3F%20And%20where%20are%20methods%20defined%3F%22%2C%20%22created_at%22%3A%20%222015-10-26T23%3A39%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/585279%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mitar%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20think%20the%20publish%20functions%2C%20methods%2C%20templates%2C%20and%20routes%20for%20a%20particular%20feature%20will%20be%20in%20the%20same%20directory%3B%20depending%20on%20what%20is%20sane%2C%20there%20might%20be%20one%20or%20more%20per%20file.%20I%27d%20prefer%20one%2C%20but%20that%20might%20be%20too%20many%20files%20for%20some.%22%2C%20%22created_at%22%3A%20%222015-10-26T23%3A51%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20am%20saying%20that%20there%20are%20publish%20endpoints%20and%20methods%20which%20are%20linked%20to%20a%20feature.%20And%20there%20are%20some%20which%20are%20not.%20For%20example%2C%20publish%20blog%20posts%20can%20be%20used%20not%20just%20in%20display%20of%20blog%20posts%2C%20but%20also%20in%20stats%2C%20and%20in%20notifications%2C%20and%20in%20tagging%20view%20and%20so%20on.%20While%20update%20password%20method%20is%20probably%20used%20only%20from%20the%20update%20form%20view.%5Cr%5Cn%5Cr%5CnSo%20you%20have%20two%20types%20of%20publish%20functions%20and%20methods.%20One%20connected%20to%20a%20view/feature.%20And%20one%20independent%20which%20are%20reused%20across%20many%20features.%20%28Often%20they%20are%20pretty%20generic%2C%20like%20%5C%22all%20posts%20from%20the%20user%5C%22.%29%22%2C%20%22created_at%22%3A%20%222015-10-27T06%3A47%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/585279%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mitar%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20don%27t%20think%20features%20should%20be%20all%20based%20on%20client%20side%20stuff.%20So%20in%20this%20case%20I%27d%20have%20a%20%5C%22posts%5C%22%20feature%20which%20is%20just%20generic%20post%20stuff.%22%2C%20%22created_at%22%3A%20%222015-10-27T07%3A00%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22But%20then%20you%20have%20some%20publish%20things%20away%20from%20the%20other%20feature%3F%20So%20some%20feature%20then%20uses%20also%20the%20%5C%22posts%5C%22%20feature%3F%22%2C%20%22created_at%22%3A%20%222015-10-27T07%3A10%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/585279%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mitar%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yeah%2C%20I%20think%20this%20is%20a%20place%20where%20we%20need%20more%20clarity.%20I%20think%20in%20mine%20and%20%40tmeasday%27s%20mind%20there%20is%20some%20nebulous%20concept%20of%20%5C%22module%5C%22%2C%20%5C%22feature%5C%22%2C%20or%20similar%2C%20but%20we%20should%20make%20it%20clear%20what%20we%20mean%20by%20this.%22%2C%20%22created_at%22%3A%20%222015-10-27T17%3A18%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22So%20this%20is%20the%20structure%20which%20I%20am%20currently%20having%3A%20https%3A//github.com/mitar/council-app/tree/master/packages/council/motion%5Cr%5Cn%5Cr%5CnSo%20views%20in%20one%20directory%2C%20inside%20one%20package.%20and%20for%20publish%20and%20methods%20I%20then%20have%20another%20package%20with%20same%20directories%3A%20https%3A//github.com/mitar/council-app/tree/master/packages/api/motion%5Cr%5Cn%5Cr%5CnThe%20reason%20is%20that%20sometimes%20some%20view%20access%20the%20methods%20and%20publish%20from%20another%20directory.%22%2C%20%22created_at%22%3A%20%222015-10-27T18%3A03%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/585279%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mitar%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20guess%20I%20look%20at%20it%20like%20in%20Rails%20-%20almost%20all%20database-related%20methods%20end%20up%20being%20attached%20to%20a%20certain%20model.%20Yes%2C%20it%27s%20OK%20for%20models%20to%20reference%20each%20other%2C%20and%20sometimes%20you%20have%20controllers/views%20which%20aren%27t%20related%20to%20a%20specific%20model%2C%20but%20the%20general%20case%20seems%20to%20be%20that%20routes%20-%3E%20model%20-%3E%20controller%20-%3E%20view%20are%20mostly%20related%20to%20a%20specific%20column%20in%20the%20database.%20Perhaps%20this%20is%20an%20outdated%20mindset%20that%20comes%20from%20old-school%20rails%20dev%3F%22%2C%20%22created_at%22%3A%20%222015-10-27T18%3A09%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22So%20I%20have%20also%20a%20%5Bmodel%20package%5D%28https%3A//github.com/peerlibrary/meteor-peerdb%29%20and%20I%20tried%20few%20times%20to%20combine%20all%20these%20into%20one%20class%20%28I%20like%20OOP%20programming%20if%20you%20haven%27t%20noticed%29.%20So%20what%20I%20was%20thinking%20in%20the%20past%20was%20something%20like%3A%5Cr%5Cn%5Cr%5Cn%60%60%60%5Cr%5Cnclass%20Post%20extends%20Document%5Cr%5Cn%5Cr%5Cnclass%20Post.List%20extends%20BlazeComponent%5Cr%5Cn%20%20%40register%20%27Post.List%27%5Cr%5Cn%5Cr%5Cn%20%20onCreated%3A%20-%3E%5Cr%5Cn%20%20%20%20%40subscribe%20%27Post.list%27%5Cr%5Cn%5Cr%5CnPost.new%20%3D%20%28doc%29%20-%3E%5Cr%5Cn%20%20Meteor.call%20%27Post.new%27%2C%20doc%5Cr%5Cn%5Cr%5CnPost._new%20%3D%20%28doc%29%20-%3E%5Cr%5Cn%20%20%40insert%20doc%5Cr%5Cn%5Cr%5CnFlowRouter.route%20%27/posts%27%2C%5Cr%5Cn%20%20name%3A%20%27Post.list%27%5Cr%5Cn%20%20action%3A%20%28params%2C%20queryParams%29%20-%3E%5Cr%5Cn%20%20%20%20BlazeLayout.render%20%27Layout%27%2C%5Cr%5Cn%20%20%20%20%20%20main%3A%20%27Post.List%27%5Cr%5Cn%5Cr%5CnMeteor.methods%20%27Post.new%27%2C%20Post._new.bind%28Post%29%5Cr%5Cn%5Cr%5CnMeteor.publish%20%27Post.list%27%20-%3E%5Cr%5Cn%20%20Post.documents.find%28%29%5Cr%5Cn%60%60%60%5Cr%5Cn%5Cr%5Cn%28I%20use%20%60Post%60%20instead%20of%20%60Posts%60%20because%20they%20are%20documents%2C%20not%20collections.%20And%20I%20use%20%60Post.List%60%20instead%20of%20%60Post.list%60%20because%20it%20is%20a%20component%2C%20not%20template.%20And%20because%20%60Post.list%60%20might%20be%20a%20method.%29%5Cr%5Cn%5Cr%5CnBut%20then%2C%20there%20are%20always%20some%20exceptions.%20Methods%20which%20have%20to%20operate%20on%20both%20Posts%20and%20Comments%20and%20the%20same%20time.%20Publish%20functions%20which%20return%20multiple%20collections%20%28like%20all%20Posts%20and%20Comments%20tagged%20with%20the%20same%20tag%29.%20Where%20to%20put%20then%20those%3F%5Cr%5Cn%5Cr%5CnMaybe%20we%20should%20say%20that%20publish%20functions%20should%20always%20return%20only%20one%20collection%3F%20But%20then%20that%20limits%20a%20lot%20thins%2C%20no%3F%5Cr%5Cn%5Cr%5CnBTW%2C%20I%20am%20not%20proposing%20that%20this%20is%20structure%20and%20naming%20which%20should%20be%20proposed%20in%20the%20guide.%20Things%20change%20a%20bit%20once%20you%20have%20models%20and%20components.%20I%20think%20%60Posts%60%20is%20better%20when%20you%20have%20only%20collections%2C%20no%20models.%20And%20%60Posts.list%60%20is%20better%20when%20you%20have%20templates%20and%20no%20components.%20%28In%20this%20way%20when%20you%20do%20%60%7B%7B%3E%20Posts.list%7D%7D%60%20you%20know%20that%20you%20are%20including%20a%20template%2C%20and%20%60%7B%7B%3E%20Posts.List%7D%7D%60%20is%20a%20component.%29%22%2C%20%22created_at%22%3A%20%222015-10-27T18%3A28%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/585279%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mitar%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3E%20But%20then%2C%20there%20are%20always%20some%20exceptions.%20Methods%20which%20have%20to%20operate%20on%20both%20Posts%20and%20Comments%20and%20the%20same%20time.%20Publish%20functions%20which%20return%20multiple%20collections%20%28like%20all%20Posts%20and%20Comments%20tagged%20with%20the%20same%20tag%29.%20Where%20to%20put%20then%20those%3F%5Cr%5Cn%5Cr%5CnI%20think%20this%20is%20totally%20fine%21%20Posts%20is%20just%20a%20%5C%22theme%5C%22%20to%20group%20your%20code.%20If%20there%20is%20a%20publication%20that%20returns%20posts%20and%20their%20associated%20comments%2C%20it%20seems%20totally%20reasonable%20for%20that%20to%20be%20under%20the%20%60Posts%60%20namespace.%20I%20don%27t%20see%20why%20this%20means%20that%20things%20need%20to%20be%20split%20up%20into%20different%20modules%20just%20because%20they%20interact%20with%20more%20than%20one%20collection.%22%2C%20%22created_at%22%3A%20%222015-10-27T18%3A32%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22OK.%20I%20am%20planing%20to%20refactor%20one%20my%20app%20according%20to%20these%20guidelines%20soon%20and%20then%20I%20will%20see%20how%20clean%20it%20will%20be.%20%3A-%29%22%2C%20%22created_at%22%3A%20%222015-10-27T18%3A34%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/585279%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mitar%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yep%2C%20we%20have%20a%20task%20for%20the%20same%3A%20https%3A//github.com/meteor/guide/issues/48%22%2C%20%22created_at%22%3A%20%222015-10-27T18%3A35%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27ll%20just%20add%20one%20thing%20that%20might%20not%20have%20come%20across%20from%20my%20terse%20comments%20above%3A%5Cr%5Cn%5Cr%5CnIn%20the%20past%2C%20we%27ve%20made%20efforts%20to%20put%20an%20entire%20%5C%22slice%5C%22%20of%20the%20app%20in%20a%20package%20%28e.g.%20in%20galaxy%20we%20had%20an%20%60activity-feed%60%20package%20that%20included%20the%20collection%2C%20publications%2C%20as%20well%20as%20the%20component%20to%20render%20the%20feed%29.%5Cr%5Cn%5Cr%5CnBut%20inevitably%20we%27ve%20always%20ended%20up%20splitting%20it%20into%20the%20%5C%22business%20logic%5C%22%20part%20%28i.e.%20the%20collection%2C%20most%20of%20the%20more%20general%20methods%20%2B%20pubs%2C%20etc%20--%20a%20package%20called%20%60activities%60%29%20and%20the%20%5C%22view%5C%22%20part%20%28the%20final%20%60activity-feed%60%20package%2C%20which%20depends%20on%20%60activities%60%29.%5Cr%5Cn%5Cr%5CnI%20would%20suggest%20we%20don%27t%20suggest%20ever%20mixing%20collections%20and%20templates%20in%20a%20package%20for%20this%20reason.%20I%27m%20not%20sure%20if%20this%20is%20controversial%20or%20not.%22%2C%20%22created_at%22%3A%20%222015-10-27T23%3A37%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20don%27t%20mind%20either%20way.%22%2C%20%22created_at%22%3A%20%222015-10-28T00%3A25%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40tmeasday%3A%20Exactly%20this%20is%20also%20my%20point.%20So%20I%20am%20not%20sure%20what%20is%20the%20best%20approach.%20See%20my%20recent%20%5Bapp%5D%28https%3A//github.com/mitar/council-app%29%3A%5Cr%5Cn%2A%20%60api%60%20is%20business%20logic%2C%20publish%20and%20methods%5Cr%5Cn%2A%20%60council%60%20is%20frontend%20%28views%29%2C%20each%20%5C%22slice%5C%22%20or%20%5C%22feature%5C%22%20in%20its%20directory%5Cr%5Cn%5Cr%5CnSo%20yea%2C%20it%20seems%20like%20we%20would%20all%20like%20that%20we%20could%20split%20apps%20by%20%5C%22slices%5C%22%20%28%5C%22features%5C%22%29%20but%20then%20this%20gets%20messy.%20The%20downside%20is%20that%20then%20you%20have%20to%20coordinate%20code%20in%20two%20places.%20So%20is%20this%20just%20because%20we%20are%20used%20to%20this%20frontend/backend%20separation%3F%20But%20it%20is%20also%20true%20that%20I%20like%20the%20idea%20that%20someday%20I%20could%20create%20an%20auto-generating%20%60/api/%60%20endpoint%20which%20would%20list%20all%20public%20methods%20and%20publish%20endpoints%20people%20can%20connect%20to.%20And%20that%20all%20those%20would%20simply%20be%20in%20one%20package.%5Cr%5Cn%5Cr%5CnI%20would%20love%20to%20learn%20why%20it%20was%20%60inevitable%60%20for%20you%20to%20split%20it%20this%20way%3F%22%2C%20%22created_at%22%3A%20%222015-10-28T04%3A07%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/585279%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mitar%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27m%20not%20sure%20why%20it%20was%20inevitable.%20Just%20always%20seems%20to%20happen%20that%20way.%22%2C%20%22created_at%22%3A%20%222015-10-29T04%3A26%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22OK%2C%20but%20then%20we%20are%20not%20proposing%20to%20people%3A%5Cr%5Cn%5Cr%5Cn%3E%20Directory%20structure%20around%20features%2C%20not%20client/server%5Cr%5Cn%5Cr%5Cn%3F%22%2C%20%22created_at%22%3A%20%222015-10-29T06%3A22%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/585279%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mitar%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20think%20it%27s%20still%20possible%20to%20have%20methods%20%28or%20even%20publications%29%20that%20are%20specific%20to%20a%20feature%20%28just%20not%20collections%29.%20So%20I%20think%20it%20still%20make%20sense%20to%20say%20this.%5Cr%5Cn%5Cr%5CnLet%27s%20leave%20it%20for%20now%20and%20see%20how%20it%20feels%20when%20written%20up.%22%2C%20%22created_at%22%3A%20%222015-10-31T03%3A01%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222015-10-31T03%3A01%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20outlines/structure.md%3AL1-57%22%7D%2C%20%22Pull%20773091cc2645684ec5af371f1e423197d2d1f4c1%20outlines/structure.md%2019%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/56%23discussion_r43088274%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22We%20should%20update%20the%20skeleton%20that%27s%20produced%20by%20%60meteor%20create%60%20to%20follow%20this%20stuff%20--%20create%20a%20code%20item%3F%22%2C%20%22created_at%22%3A%20%222015-10-27T06%3A39%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22Done%20https%3A//github.com/meteor/guide/issues/59%22%2C%20%22created_at%22%3A%20%222015-10-27T17%3A24%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-10-27T17%3A53%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20outlines/structure.md%3AL1-57%22%7D%2C%20%22Pull%20d8b65ff2e10708118645c61218aa81604a467eb2%20outlines/structure.md%2016%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/56%23discussion_r43161684%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20would%20really%20suggest%20that%20we%20propose%20that%20methods%20should%20be%20delimited%20with%20%60.%60.%20Because%20once%20you%20have%20this%2C%20then%20you%20can%20use%20the%20same%20string%20for%20both%3A%5Cr%5Cn%2A%20publish%20endpoint%5Cr%5Cn%2A%20template%20name%5Cr%5Cn%2A%20route%20name%5Cr%5Cn%5Cr%5CnSo%20%60Posts.list%60%20for%20both%20route%20which%20displays%20posts%2C%20a%20publish%20which%20provides%20data%2C%20and%20a%20template%20which%20renders%20it.%22%2C%20%22created_at%22%3A%20%222015-10-27T18%3A05%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/585279%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mitar%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hmm%2C%20that%20is%20appealing%20to%20me%20as%20well.%20%40tmeasday%20what%20do%20you%20think%3F%20Perhaps%20if%20we%20want%20to%20move%20to%20URLs%20later%2C%20we%20can%20just%20replace%20%60.%60%20with%20%60/%60%20and%20it%27ll%20be%20fine.%22%2C%20%22created_at%22%3A%20%222015-10-27T18%3A10%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22So%20how%20I%20am%20thinking%20is%3A%5Cr%5Cn%5Cr%5Cn%60%60%60%5Cr%5Cn%3Ctemplate%20name%3D%5C%22Posts.list%5C%22%3E%3E%5Cr%5Cn%20%20%7B%7BpathFor%20%27Posts.list%27%7D%7D%5Cr%5Cn%3C/template%3E%5Cr%5Cn%60%60%60%5Cr%5Cn%5Cr%5CnThis%20really%20becomes%20easy%20to%20understand.%22%2C%20%22created_at%22%3A%20%222015-10-27T18%3A13%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/585279%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mitar%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yeah%20I%20think%20I%27m%20on%20board%20with%20this%2C%20let%27s%20wait%20until%20Tom%20wakes%20up%20to%20see%20what%20he%20thinks.%22%2C%20%22created_at%22%3A%20%222015-10-27T18%3A33%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20think%20our%20idea%20for%20naming%20methods%20was%20that%20we%27d%20be%20referencing%20them%20via%20the%20JS%20namespace%20anyway%2C%20and%20the%20string%20name%20would%20be%20something%20used%20internally%20for%20REST%2BDDP%20paths.%5Cr%5Cn%5Cr%5CnSo%20in%20this%20case%2C%20the%20method%20would%20be%20%60Posts.methods.list%20%3D%20new%20Method%28%7Bname%3A%20%27posts/methods/list%60%7D%29%60%20or%20something%20%28have%20we%20decided%20on%20a%20sub-namespace%20for%20methods%20%40stubailo%3F%29.%5Cr%5Cn%5Cr%5CnI%27m%20definitely%20on%20board%20with%20the%20three%20names%20you%20mentioned%20being%20the%20same.%20I%27m%20not%20quite%20sure%20I%20see%20that%20the%20method%20is%20quite%20as%20tightly%20bound/coupled%20as%20the%20route/template/publication%20though.%20As%20an%20example%2C%20I%27d%20probably%20want%20to%20call%20a%20method%20something%20like%20%60Posts.insert%60%20but%20the%20template/route%20would%20probably%20be%20called%20%60Posts.new%60%20or%20something.%22%2C%20%22created_at%22%3A%20%222015-10-27T23%3A32%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22Why%20not%20call%20the%20method%20%60Posts.new%60%3F%20I%20feel%20like%20there%20will%20be%20a%20tight%20form%20%3C-%3E%20method%20coupling%20in%20our%20proposed%20architecture.%22%2C%20%22created_at%22%3A%20%222015-10-28T00%3A10%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20guess%20we%20could.%20I%20think%20we%20need%20a%20sub-namespace%20for%20methods%20and%20pubs%20though...%22%2C%20%22created_at%22%3A%20%222015-10-28T00%3A21%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22Perhaps%20we%20can%20leave%20this%20outline%20a%20little%20more%20vague%20and%20just%20hash%20it%20out%20in%20the%20example%20app.%22%2C%20%22created_at%22%3A%20%222015-10-28T00%3A26%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yea%2C%20I%20think%20we%20are%20introducing%20too%20many%20new%20concepts%20here.%20%60new%20Method%60%3F%20I%20like%20the%20idea%20that%20it%20would%20be%20like%20that%2C%20but%20it%20is%20not.%20We%20are%20making%20guide%20for%20what%20we%20have%20currently%2C%20not%20what%20we%20would%20want%20in%20the%20future%20to%20be.%20We%20can%20do%20that%20in%20iterations%20and%20improve%20in%20the%20future.%5Cr%5Cn%5Cr%5CnBTW%2C%20I%20did%20something%20similar%20in%20%5Bthis%20package%5D%28https%3A//github.com/peerlibrary/meteor-middleware%29%2C%20made%20publish%20endpoints%20%60new%20PublishEndpoint%60.%20The%20idea%20is%20that%20this%20allows%20you%20%28later%20on%29%20to%20attach%20also%20documentation%20to%20the%20publish%20endpoint.%20And%20also%20stack%20transformations.%5Cr%5Cn%5Cr%5CnBut%20currently%20Meteor%20is%20more%20functions%20and%20callbacks%20oriented%2C%20so%20let%27s%20describe%20that.%22%2C%20%22created_at%22%3A%20%222015-10-28T04%3A10%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/585279%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mitar%22%7D%7D%2C%20%7B%22body%22%3A%20%22We%20need%20somewhere%20to%20hang%20the%20validation%20part%20of%20the%20method%20for%20as-you-type%20validation%20of%20forms.%20This%20is%20one%20of%20the%20%28very%20few%29%20new%20concepts%20that%20we%20decided%20we%20need%20to%20add.%22%2C%20%22created_at%22%3A%20%222015-10-28T04%3A15%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22Should%20this%20really%20be%20in%20core%20for%20now%3F%20This%20is%20really%20then%20one%20big%20can%20of%20worms.%20How%20you%20then%20make%20internationalization%20of%20messages%2C%20for%20example%3F%20What%20we%20did%20for%20example%20in%20the%20past%20was%20that%20we%20added%20extra%20stuff%20to%20%60Meteor.Error%60%20on%20the%20server%20side%20so%20that%20%60check%60%20could%20tell%20which%20field%20failed%2C%20so%20that%20you%20could%20color%20that%20correctly%20in%20the%20form%2C%20when%20validation%20failed.%20But%20we%20abandoned%20that%20with%20a%20pattern%20that%20validation%20should%20not%20be%20part%20of%20method%20interface.%20Method%20is%20more%20like%20business%20logic%20API.%20You%20get%20it%20right%20or%20you%20get%20400%20error.%20%60check%60%20assures%20that.%20And%20then%20you%20build%20on%20top%20of%20this%20a%20higher-level%20form%20field%20component%20which%20does%20all%20the%20fancy%20stuff%20of%20validating%20on%20the%20client%2C%20animation%20error%20messages%2C%20and%20flashing%20red%20colors%2C%20and%20once%20it%20let%27s%20it%20go%20through%2C%20you%20make%20a%20method%20call%20and%20you%20expect%20it%20to%20succeed.%20And%20higher-level%20stuff%20can%20also%20automatically%20generate%20such%20methods%20which%20prepend%20%60check%60s%20at%20the%20beginning.%5Cr%5Cn%5Cr%5CnBTW%2C%20there%20is%20also%20the%20issue%20that%20it%20would%20be%20great%20that%20all%20form%20submissions%20would%20get%20disabled%20when%20connection%20to%20the%20server%20is%20lost.%20But%20this%20should%20probably%20not%20be%20part%20of%20core.%22%2C%20%22created_at%22%3A%20%222015-10-28T04%3A22%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/585279%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mitar%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yeah%2C%20we%20went%20through%20the%20exact%20same%20thought%20process%20but%20it%20turns%20out%20that%3A%5Cr%5Cn%5Cr%5Cn1.%20You%20can%27t%20always%20validate%20on%20the%20client.%20Sometimes%20you%20have%20to%20validate%20on%20the%20server%20%28eg.%20uniqueness%29%5Cr%5Cn2.%20%60Meteor.error%60%20has%20a%20%60details%60%20field%20for%20a%20reason.%20Take%20a%20look%20at%20what%20the%20accounts%20code%20does%2C%20methods%20are%20supposed%20to%20throw%20meaningful%20errors.%5Cr%5Cn3.%20It%20doesn%27t%20make%20sense%20to%20both%20validate%20on%20the%20client%20and%20then%20do%20the%20exact%20same%20validation%20in%20the%20simulation%20of%20the%20method.%20You%20might%20as%20well%20just%20use%20the%20simulation%20for%20client%20side%20validation.%5Cr%5Cn%5Cr%5CnAll%20of%20this%20has%20led%20me%20to%20very%20firmly%20believe%20that%20a%20simpler%20pattern%20is%20possible%20if%20the%20method%20does%20the%20validation.%20And%20it%20is%21%22%2C%20%22created_at%22%3A%20%222015-10-28T04%3A38%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes%2C%20but%20then%20you%20loose%20UI%20goodies.%20%3A-%29%20Then%20stuff%20becomes%20like%2090s%20CGI%20forms.%20%3A-%29%22%2C%20%22created_at%22%3A%20%222015-10-28T04%3A42%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/585279%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mitar%22%7D%7D%2C%20%7B%22body%22%3A%20%22Anyway%2C%20why%20you%20have%20to%20extend%20%60Method%60%20for%20this%3F%20This%20is%20all%20what%20we%20needed%3A%20https%3A//github.com/peerlibrary/peerlibrary/blob/master/lib/errors.coffee%5Cr%5Cn%5Cr%5Cn%28And%20then%20we%20parse%20%60Argument%60%20out%20of%20%60details%60.%29%22%2C%20%22created_at%22%3A%20%222015-10-28T04%3A44%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/585279%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mitar%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3E%20Yes%2C%20but%20then%20you%20loose%20UI%20goodies.%20%3A-%29%20Then%20stuff%20becomes%20like%2090s%20CGI%20forms.%20%3A-%29%5Cr%5Cn%5Cr%5CnNot%20if%20the%20Method%20is%20separated%20into%20validation%20and%20body.%20Thus%20this%20conversation.%5Cr%5Cn%5Cr%5Cn%3E%20Anyway%2C%20why%20you%20have%20to%20extend%20Method%20for%20this%3F%20This%20is%20all%20what%20we%20needed%3A%20https%3A//github.com/peerlibrary/peerlibrary/blob/master/lib/errors.coffee%5Cr%5Cn%5Cr%5CnYeah%20the%20format%20of%20the%20validation%20error%20is%20the%20subject%20of%20https%3A//github.com/meteor/guide/issues/51%22%2C%20%22created_at%22%3A%20%222015-10-28T04%3A47%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22OK%20I%20copied%20all%20of%20the%20naming%20guidelines%20into%20the%20bottom%20of%20the%20outline%20instead%20of%20linking%20to%20a%20comment.%20I%20added%20a%20note%20at%20the%20top%20of%20the%20method%20part%20saying%20it%27s%20up%20for%20debate%3B%20we%20should%20see%20how%20the%20whole%20%60new%20Method%60%20thing%20works%20out%2C%20and%20also%20see%20what%20it%27s%20like%20as%20part%20of%20the%20example%20app.%5Cr%5Cn%5Cr%5CnEither%20way%2C%20I%20don%27t%20think%20it%27s%20the%20end%20of%20the%20world%20-%20at%20the%20end%20of%20the%20day%20we%20just%20need%20to%20pick%20something.%22%2C%20%22created_at%22%3A%20%222015-10-30T17%3A13%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222015-10-30T17%3A13%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20outlines/structure.md%3AL1-57%22%7D%2C%20%22Pull%20d8b65ff2e10708118645c61218aa81604a467eb2%20outlines/structure.md%2010%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/56%23discussion_r43210985%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20should%20have%20a%20new%20section%2C%20how%20to%20use%20packages%20-%20tells%20you%20how%20to%20add%20packages%20from%20Atmosphere%2C%20how%20to%20use%20NPM%20modules%20on%20the%20client/server%2C%20and%20then%20links%20off%20to%20the%20packages%20chapter%20for%20more%20detail.%22%2C%20%22created_at%22%3A%20%222015-10-28T01%3A41%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22Although%20with%20all%20of%20the%20sync%20API%20stuff%20and%20possibly%20more%20details%2C%20it%20seems%20like%20this%20might%20not%20be%20the%20right%20place%20for%20this%20information.%20%40tmeasday%2C%20do%20you%20have%20any%20thoughts%20on%20where%20information%20about%20NPM%2C%20Fibers%2C%20etc%20should%20go%3F%22%2C%20%22created_at%22%3A%20%222015-10-28T01%3A46%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22Should%20we%20just%20link%20to%20some%203rd%20party%20info%3F%20We%20have%20some%20resources%20on%20the%20DM%20blog%20about%20it.%5Cr%5Cn%5Cr%5CnDo%20you%20mean%20if%20you%20include%20a%20npm%20package%20directly%2C%20you%20need%20to%20know%20how%20to%20use%20%60Meteor.wrapAsync%60%20to%20use%20it%20properly%3F%5Cr%5Cn%5Cr%5Cn%28...%20promises%20...%29%22%2C%20%22created_at%22%3A%20%222015-10-28T01%3A54%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20feel%20like%20NPM%20is%20too%20important%20of%20a%20topic%20to%20leave%20to%20third-party%20stuff%3F%20I%20can%27t%20imagine%20writing%20any%20serious%20app%20without%20using%20something%20from%20NPM.%22%2C%20%22created_at%22%3A%20%222015-10-28T01%3A58%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yeah%2C%20sure%20but%20if%20it%27s%20just%20%5C%22here%27s%20how%20to%20use%20%60wrapAsync%60%5C%22%20I%20think%20that%27s%20good.%20If%20it%27s%20a%20whole%20section%20on%20writing%20packages%20that%20wrap%20NPM%2C%20I%27m%20less%20sure.%22%2C%20%22created_at%22%3A%20%222015-10-28T02%3A03%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yeah%20I%20mean%20if%20that%20existed%20it%20would%20probably%20go%20in%20the%20packaging%20guide.%20This%20is%20strictly%20what%20app%20authors%20need%20to%20know%20to%20use%20npm%20stuff.%22%2C%20%22created_at%22%3A%20%222015-10-28T02%3A06%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes%2C%20I%20do%20not%20think%20app%20authors%20should%20be%20using%20%60wrapAsync%60.%20Package%20maintainers%20should%20use%20it%20to%20expose%20sync-version%20of%20APIs.%22%2C%20%22created_at%22%3A%20%222015-10-28T04%3A14%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/585279%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mitar%22%7D%7D%2C%20%7B%22body%22%3A%20%22Well%20they%20have%20to%20if%20they%20are%20going%20to%20use%20%60meteorhacks%3Anpm%60%20no%3F%5Cr%5Cn%5Cr%5CnI%20take%20Mitar%27s%20point%20about%20encouraging%20package%20maintainers%20to%20do%20it%2C%20but%20I%20think%20the%20idea%20of%20every%20NPM%20package%20being%20wrapped%20by%20a%20well%20maintained%20Meteor%20package%20has%20been%20thoroughly%20debunked.%20The%20important%20ones%20maybe%20thanks%20to%20heroism%20on%20the%20part%20of%20%40dandv%20and%20others%2C%20but%20I%20think%20the%20future%20doesn%27t%20look%20like%20that.%22%2C%20%22created_at%22%3A%20%222015-10-28T04%3A20%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes%2C%20but%20also%20because%20people%20do%20not%20see%20the%20benefit.%20Because%20it%20was%20never%20clearly%20publicized.%20What%20is%20%5C%22Meteor%20grade%20package%5C%22.%20Most%20people%20see%20it%20as%20a%20nuisance.%20%5C%22Why%20you%20have%20to%20do%20this%20NPM%20wrapping%3F%5C%22%20Because%20they%20do%20not%20see%20benefits.%22%2C%20%22created_at%22%3A%20%222015-10-28T04%3A24%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/585279%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mitar%22%7D%7D%2C%20%7B%22body%22%3A%20%22NPM%20will%20now%20be%20in%20the%20build%20tool%20section%3A%20https%3A//github.com/meteor/guide/pull/67%22%2C%20%22created_at%22%3A%20%222015-10-30T17%3A05%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222015-10-30T17%3A05%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20outlines/structure.md%3AL1-57%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull 773091cc2645684ec5af371f1e423197d2d1f4c1 outlines/structure.md 21'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/56#discussion_r43068705'>File: outlines/structure.md:L1-57</a></b>
- <a href='https://github.com/mitar'><img border=0 src='https://avatars.githubusercontent.com/u/585279?v=3' height=16 width=16'></a> Where are publish function? And where are methods defined?
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> I think the publish functions, methods, templates, and routes for a particular feature will be in the same directory; depending on what is sane, there might be one or more per file. I'd prefer one, but that might be too many files for some.
- <a href='https://github.com/mitar'><img border=0 src='https://avatars.githubusercontent.com/u/585279?v=3' height=16 width=16'></a> I am saying that there are publish endpoints and methods which are linked to a feature. And there are some which are not. For example, publish blog posts can be used not just in display of blog posts, but also in stats, and in notifications, and in tagging view and so on. While update password method is probably used only from the update form view.
So you have two types of publish functions and methods. One connected to a view/feature. And one independent which are reused across many features. (Often they are pretty generic, like "all posts from the user".)
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> I don't think features should be all based on client side stuff. So in this case I'd have a "posts" feature which is just generic post stuff.
- <a href='https://github.com/mitar'><img border=0 src='https://avatars.githubusercontent.com/u/585279?v=3' height=16 width=16'></a> But then you have some publish things away from the other feature? So some feature then uses also the "posts" feature?
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Yeah, I think this is a place where we need more clarity. I think in mine and @tmeasday's mind there is some nebulous concept of "module", "feature", or similar, but we should make it clear what we mean by this.
- <a href='https://github.com/mitar'><img border=0 src='https://avatars.githubusercontent.com/u/585279?v=3' height=16 width=16'></a> So this is the structure which I am currently having: https://github.com/mitar/council-app/tree/master/packages/council/motion
So views in one directory, inside one package. and for publish and methods I then have another package with same directories: https://github.com/mitar/council-app/tree/master/packages/api/motion
The reason is that sometimes some view access the methods and publish from another directory.
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> I guess I look at it like in Rails - almost all database-related methods end up being attached to a certain model. Yes, it's OK for models to reference each other, and sometimes you have controllers/views which aren't related to a specific model, but the general case seems to be that routes -> model -> controller -> view are mostly related to a specific column in the database. Perhaps this is an outdated mindset that comes from old-school rails dev?
- <a href='https://github.com/mitar'><img border=0 src='https://avatars.githubusercontent.com/u/585279?v=3' height=16 width=16'></a> So I have also a [model package](https://github.com/peerlibrary/meteor-peerdb) and I tried few times to combine all these into one class (I like OOP programming if you haven't noticed). So what I was thinking in the past was something like:
```
class Post extends Document
class Post.List extends BlazeComponent
@register 'Post.List'
onCreated: ->
@subscribe 'Post.list'
Post.new = (doc) ->
Meteor.call 'Post.new', doc
Post._new = (doc) ->
@insert doc
FlowRouter.route '/posts',
name: 'Post.list'
action: (params, queryParams) ->
BlazeLayout.render 'Layout',
main: 'Post.List'
Meteor.methods 'Post.new', Post._new.bind(Post)
Meteor.publish 'Post.list' ->
Post.documents.find()
```
(I use `Post` instead of `Posts` because they are documents, not collections. And I use `Post.List` instead of `Post.list` because it is a component, not template. And because `Post.list` might be a method.)
But then, there are always some exceptions. Methods which have to operate on both Posts and Comments and the same time. Publish functions which return multiple collections (like all Posts and Comments tagged with the same tag). Where to put then those?
Maybe we should say that publish functions should always return only one collection? But then that limits a lot thins, no?
BTW, I am not proposing that this is structure and naming which should be proposed in the guide. Things change a bit once you have models and components. I think `Posts` is better when you have only collections, no models. And `Posts.list` is better when you have templates and no components. (In this way when you do `{{> Posts.list}}` you know that you are including a template, and `{{> Posts.List}}` is a component.)
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> > But then, there are always some exceptions. Methods which have to operate on both Posts and Comments and the same time. Publish functions which return multiple collections (like all Posts and Comments tagged with the same tag). Where to put then those?
I think this is totally fine! Posts is just a "theme" to group your code. If there is a publication that returns posts and their associated comments, it seems totally reasonable for that to be under the `Posts` namespace. I don't see why this means that things need to be split up into different modules just because they interact with more than one collection.
- <a href='https://github.com/mitar'><img border=0 src='https://avatars.githubusercontent.com/u/585279?v=3' height=16 width=16'></a> OK. I am planing to refactor one my app according to these guidelines soon and then I will see how clean it will be. :-)
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Yep, we have a task for the same: https://github.com/meteor/guide/issues/48
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> I'll just add one thing that might not have come across from my terse comments above:
In the past, we've made efforts to put an entire "slice" of the app in a package (e.g. in galaxy we had an `activity-feed` package that included the collection, publications, as well as the component to render the feed).
But inevitably we've always ended up splitting it into the "business logic" part (i.e. the collection, most of the more general methods + pubs, etc -- a package called `activities`) and the "view" part (the final `activity-feed` package, which depends on `activities`).
I would suggest we don't suggest ever mixing collections and templates in a package for this reason. I'm not sure if this is controversial or not.
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> I don't mind either way.
- <a href='https://github.com/mitar'><img border=0 src='https://avatars.githubusercontent.com/u/585279?v=3' height=16 width=16'></a> @tmeasday: Exactly this is also my point. So I am not sure what is the best approach. See my recent [app](https://github.com/mitar/council-app):
* `api` is business logic, publish and methods
* `council` is frontend (views), each "slice" or "feature" in its directory
So yea, it seems like we would all like that we could split apps by "slices" ("features") but then this gets messy. The downside is that then you have to coordinate code in two places. So is this just because we are used to this frontend/backend separation? But it is also true that I like the idea that someday I could create an auto-generating `/api/` endpoint which would list all public methods and publish endpoints people can connect to. And that all those would simply be in one package.
I would love to learn why it was `inevitable` for you to split it this way?
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> I'm not sure why it was inevitable. Just always seems to happen that way.
- <a href='https://github.com/mitar'><img border=0 src='https://avatars.githubusercontent.com/u/585279?v=3' height=16 width=16'></a> OK, but then we are not proposing to people:
> Directory structure around features, not client/server
?
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> I think it's still possible to have methods (or even publications) that are specific to a feature (just not collections). So I think it still make sense to say this.
Let's leave it for now and see how it feels when written up.
- [x] <a href='#crh-comment-Pull 773091cc2645684ec5af371f1e423197d2d1f4c1 outlines/structure.md 19'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/56#discussion_r43088274'>File: outlines/structure.md:L1-57</a></b>
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> We should update the skeleton that's produced by `meteor create` to follow this stuff -- create a code item?
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Done https://github.com/meteor/guide/issues/59
- [x] <a href='#crh-comment-Pull 773091cc2645684ec5af371f1e423197d2d1f4c1 outlines/structure.md 22'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/56#discussion_r43088464'>File: outlines/structure.md:L1-57</a></b>
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> Do we recommend like a `lib/` or `utils/` directory for all re-usable stuff (less + js?)
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Yes, I think we should do that. I guess in Meteor 1.3 it will be the `imports` directory?
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Added mention of that.
- [x] <a href='#crh-comment-Pull d8b65ff2e10708118645c61218aa81604a467eb2 outlines/structure.md 16'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/56#discussion_r43161684'>File: outlines/structure.md:L1-57</a></b>
- <a href='https://github.com/mitar'><img border=0 src='https://avatars.githubusercontent.com/u/585279?v=3' height=16 width=16'></a> I would really suggest that we propose that methods should be delimited with `.`. Because once you have this, then you can use the same string for both:
* publish endpoint
* template name
* route name
So `Posts.list` for both route which displays posts, a publish which provides data, and a template which renders it.
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Hmm, that is appealing to me as well. @tmeasday what do you think? Perhaps if we want to move to URLs later, we can just replace `.` with `/` and it'll be fine.
- <a href='https://github.com/mitar'><img border=0 src='https://avatars.githubusercontent.com/u/585279?v=3' height=16 width=16'></a> So how I am thinking is:
```
<template name="Posts.list">>
{{pathFor 'Posts.list'}}
</template>
```
This really becomes easy to understand.
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Yeah I think I'm on board with this, let's wait until Tom wakes up to see what he thinks.
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> I think our idea for naming methods was that we'd be referencing them via the JS namespace anyway, and the string name would be something used internally for REST+DDP paths.
So in this case, the method would be `Posts.methods.list = new Method({name: 'posts/methods/list`})` or something (have we decided on a sub-namespace for methods @stubailo?).
I'm definitely on board with the three names you mentioned being the same. I'm not quite sure I see that the method is quite as tightly bound/coupled as the route/template/publication though. As an example, I'd probably want to call a method something like `Posts.insert` but the template/route would probably be called `Posts.new` or something.
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Why not call the method `Posts.new`? I feel like there will be a tight form <-> method coupling in our proposed architecture.
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> I guess we could. I think we need a sub-namespace for methods and pubs though...
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Perhaps we can leave this outline a little more vague and just hash it out in the example app.
- <a href='https://github.com/mitar'><img border=0 src='https://avatars.githubusercontent.com/u/585279?v=3' height=16 width=16'></a> Yea, I think we are introducing too many new concepts here. `new Method`? I like the idea that it would be like that, but it is not. We are making guide for what we have currently, not what we would want in the future to be. We can do that in iterations and improve in the future.
BTW, I did something similar in [this package](https://github.com/peerlibrary/meteor-middleware), made publish endpoints `new PublishEndpoint`. The idea is that this allows you (later on) to attach also documentation to the publish endpoint. And also stack transformations.
But currently Meteor is more functions and callbacks oriented, so let's describe that.
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> We need somewhere to hang the validation part of the method for as-you-type validation of forms. This is one of the (very few) new concepts that we decided we need to add.
- <a href='https://github.com/mitar'><img border=0 src='https://avatars.githubusercontent.com/u/585279?v=3' height=16 width=16'></a> Should this really be in core for now? This is really then one big can of worms. How you then make internationalization of messages, for example? What we did for example in the past was that we added extra stuff to `Meteor.Error` on the server side so that `check` could tell which field failed, so that you could color that correctly in the form, when validation failed. But we abandoned that with a pattern that validation should not be part of method interface. Method is more like business logic API. You get it right or you get 400 error. `check` assures that. And then you build on top of this a higher-level form field component which does all the fancy stuff of validating on the client, animation error messages, and flashing red colors, and once it let's it go through, you make a method call and you expect it to succeed. And higher-level stuff can also automatically generate such methods which prepend `check`s at the beginning.
BTW, there is also the issue that it would be great that all form submissions would get disabled when connection to the server is lost. But this should probably not be part of core.
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> Yeah, we went through the exact same thought process but it turns out that:
1. You can't always validate on the client. Sometimes you have to validate on the server (eg. uniqueness)
2. `Meteor.error` has a `details` field for a reason. Take a look at what the accounts code does, methods are supposed to throw meaningful errors.
3. It doesn't make sense to both validate on the client and then do the exact same validation in the simulation of the method. You might as well just use the simulation for client side validation.
All of this has led me to very firmly believe that a simpler pattern is possible if the method does the validation. And it is!
- <a href='https://github.com/mitar'><img border=0 src='https://avatars.githubusercontent.com/u/585279?v=3' height=16 width=16'></a> Yes, but then you loose UI goodies. :-) Then stuff becomes like 90s CGI forms. :-)
- <a href='https://github.com/mitar'><img border=0 src='https://avatars.githubusercontent.com/u/585279?v=3' height=16 width=16'></a> Anyway, why you have to extend `Method` for this? This is all what we needed: https://github.com/peerlibrary/peerlibrary/blob/master/lib/errors.coffee
(And then we parse `Argument` out of `details`.)
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> > Yes, but then you loose UI goodies. :-) Then stuff becomes like 90s CGI forms. :-)
Not if the Method is separated into validation and body. Thus this conversation.
> Anyway, why you have to extend Method for this? This is all what we needed: https://github.com/peerlibrary/peerlibrary/blob/master/lib/errors.coffee
Yeah the format of the validation error is the subject of https://github.com/meteor/guide/issues/51
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> OK I copied all of the naming guidelines into the bottom of the outline instead of linking to a comment. I added a note at the top of the method part saying it's up for debate; we should see how the whole `new Method` thing works out, and also see what it's like as part of the example app.
Either way, I don't think it's the end of the world - at the end of the day we just need to pick something.
- [x] <a href='#crh-comment-Pull d8b65ff2e10708118645c61218aa81604a467eb2 outlines/structure.md 10'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/56#discussion_r43210985'>File: outlines/structure.md:L1-57</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> This should have a new section, how to use packages - tells you how to add packages from Atmosphere, how to use NPM modules on the client/server, and then links off to the packages chapter for more detail.
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Although with all of the sync API stuff and possibly more details, it seems like this might not be the right place for this information. @tmeasday, do you have any thoughts on where information about NPM, Fibers, etc should go?
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> Should we just link to some 3rd party info? We have some resources on the DM blog about it.
Do you mean if you include a npm package directly, you need to know how to use `Meteor.wrapAsync` to use it properly?
(... promises ...)
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> I feel like NPM is too important of a topic to leave to third-party stuff? I can't imagine writing any serious app without using something from NPM.
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> Yeah, sure but if it's just "here's how to use `wrapAsync`" I think that's good. If it's a whole section on writing packages that wrap NPM, I'm less sure.
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Yeah I mean if that existed it would probably go in the packaging guide. This is strictly what app authors need to know to use npm stuff.
- <a href='https://github.com/mitar'><img border=0 src='https://avatars.githubusercontent.com/u/585279?v=3' height=16 width=16'></a> Yes, I do not think app authors should be using `wrapAsync`. Package maintainers should use it to expose sync-version of APIs.
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> Well they have to if they are going to use `meteorhacks:npm` no?
I take Mitar's point about encouraging package maintainers to do it, but I think the idea of every NPM package being wrapped by a well maintained Meteor package has been thoroughly debunked. The important ones maybe thanks to heroism on the part of @dandv and others, but I think the future doesn't look like that.
- <a href='https://github.com/mitar'><img border=0 src='https://avatars.githubusercontent.com/u/585279?v=3' height=16 width=16'></a> Yes, but also because people do not see the benefit. Because it was never clearly publicized. What is "Meteor grade package". Most people see it as a nuisance. "Why you have to do this NPM wrapping?" Because they do not see benefits.
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> NPM will now be in the build tool section: https://github.com/meteor/guide/pull/67


<a href='https://www.codereviewhub.com/meteor/guide/pull/56?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/meteor/guide/pull/56?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/meteor/guide/pull/56'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>