### PR TITLE
First pass at data loading outline

### DIFF
--- a/outlines/data-loading.md
+++ b/outlines/data-loading.md
@@ -1,0 +1,33 @@
+# Data Loading and Management
+
+1. Publications + Subscriptions
+  1. What are they? - compare REST endpoint
+  2. How do they work? - talk about briding collections
+  3. What's a pub / what's a sub
+2. Defining a publication on the server
+  1. Rules around what arguments it should take
+  2. Where should it go? (which package -- depends on universality)
+3. Subscribing on the client
+  1. Subscriptions should be initiated by templates/components that need the data
+  2. Global required data should be subscribed by an always there "layout" template
+  3. Retrieve the data from the sub at the same point as subscribing, pass down and filter via `cursor-utils`
+  4. Monitoring subscription readiness + errors
+  5. UX patterns around the above (throw out to UX chapter)
+  6. Subscriptions + changing inputs
+4. Other data -- client only data
+  1. Concept of a "store"---local collection or reactive dict
+  2. How to listen to a store (autorun / helper / getMeteorData / angular version?)
+5. Updating data
+  1. Method call flow chart
+  2. Updating store data -- "actions"
+6. Publishing relational data
+  1. Common misconceptions about publication reactivity + naive implementation
+  2. Using publish-composite to get it done
+  3. Paginating lists (UI/UX chapter)
+7. Complex authorization in publications
+  1. Is kind of impossible to do correctly - https://github.com/meteor/meteor/issues/5529 (unelss we recommend a fully reactive publish solution, which we don't)
+8. Publishing non-mongo data
+  1. Custom publication patterns
+  2. Poll-publish [can we publish our Galaxy package here? or has someone made this?]
+  3. Be super careful about leaking!! (How to detect this)
+9. Turning pubs into REST endpoints.

--- a/outlines/data-loading.md
+++ b/outlines/data-loading.md
@@ -2,7 +2,7 @@
 
 1. Publications + Subscriptions
   1. What are they? - compare REST endpoint
-  2. How do they work? - talk about briding collections
+  2. How do they work? - talk about bridging data from server-client collections
   3. What's a pub / what's a sub
 2. Defining a publication on the server
   1. Rules around what arguments it should take
@@ -13,7 +13,7 @@
   3. Retrieve the data from the sub at the same point as subscribing, pass down and filter via `cursor-utils`
   4. Monitoring subscription readiness + errors
   5. UX patterns around the above (throw out to UX chapter)
-  6. Subscriptions + changing inputs
+  6. Subscriptions + changing inputs, how autoruns can help.
 4. Other data -- client only data
   1. Concept of a "store"---local collection or reactive dict
   2. How to listen to a store (autorun / helper / getMeteorData / angular version?)
@@ -27,7 +27,7 @@
 7. Complex authorization in publications
   1. Is kind of impossible to do correctly - https://github.com/meteor/meteor/issues/5529 (unelss we recommend a fully reactive publish solution, which we don't)
 8. Publishing non-mongo data
-  1. Custom publication patterns
+  1. Custom publication patterns - how to decouple your backend data format from your frontend (if you want!)
   2. Poll-publish [can we publish our Galaxy package here? or has someone made this?]
   3. Be super careful about leaking!! (How to detect this)
-9. Turning pubs into REST endpoints.
+9. Turning pubs into REST endpoints (via `simple:rest`)

--- a/outlines/data-loading.md
+++ b/outlines/data-loading.md
@@ -11,18 +11,42 @@
   1. Subscriptions should be initiated by templates/components that need the data
   2. Global required data should be subscribed by an always there "layout" template
   3. Retrieve the data from the sub at the same point as subscribing, pass down and filter via `cursor-utils`
+4. Data loading patterns
   4. Monitoring subscription readiness + errors
-  5. UX patterns around the above (throw out to UX chapter)
-  6. Subscriptions + changing inputs, how autoruns can help.
-4. Other data -- client only data
-  1. Concept of a "store"---local collection or reactive dict
-  2. How to listen to a store (autorun / helper / getMeteorData / angular version?)
-5. Updating data
-  1. Method call flow chart
-  2. Updating store data -- "actions"
+    1. Using `Template.subscriptionsReady`
+    2. Passing subscription readiness into sub-components alongside data (see UI/UX chapter)
+  5. Subscriptions + changing inputs, how autoruns can help.
+    1. Basic techniques using `this.autorun`/other reactive contexts and `Template.currentData()`/other reactive sources
+    2. How it works
+      1. The subscription realizes it's called from within a reactive context
+      2. When invalidated, subscription marks itself invalid
+      3. When re-running, if re-run with the same arguments, the sub is a no-op
+      4. Otherwise the new sub starts, *goes ready*, then the old sub is stopped.
+  6. Paginating subscription data -- combining the above
+    1. A basic paginated publication
+    2. A publication that returns a count
+    3. Passing pagination info into a template/component
+      1. `totalCount`, `requested`, `currentItems`
+    4. Passing a `loadMore` callback into a template/component, using it to increment `requested`.
+4. Other data -- global client only data
+  1. Concept of a "store"
+  2. Types of store:
+    1. If it's a single dimension, use a reactive var
+    2. If it's a few dimensions (or you need HCR), use a named reactive dict
+    3. If you need to query it, use a local collection.
+  3. How to listen to a store (autorun / helper / getMeteorData / angular version?)
+  4. How to update a store:
+    1. Built in APIs
+    2. Adding APIs to stores via `XStore.foo = () => {}` (they are singletons, so no need to make class)
+5. Updating data via methods
+  1. See forms chapter, advanced methods section for details
+  2. Method call flow chart
 6. Publishing relational data
   1. Common misconceptions about publication reactivity + naive implementation
-  2. Using publish-composite to get it done
+    1. There's no reactivity in a publish function apart from:
+      1. `userId`
+      2. The way that `publishCursor` works.
+  2. Using publish-composite to get it done the way you'd expect.
   3. Paginating lists (UI/UX chapter)
 7. Complex authorization in publications
   1. Is kind of impossible to do correctly - https://github.com/meteor/meteor/issues/5529 (unelss we recommend a fully reactive publish solution, which we don't)


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/meteor/guide/pull/63%23discussion_r43217143%22%2C%20%22https%3A//github.com/meteor/guide/pull/63%23discussion_r43217288%22%2C%20%22https%3A//github.com/meteor/guide/pull/63%23discussion_r43217353%22%2C%20%22https%3A//github.com/meteor/guide/pull/63%23discussion_r43217509%22%2C%20%22https%3A//github.com/meteor/guide/pull/63%23discussion_r43285715%22%2C%20%22https%3A//github.com/meteor/guide/pull/63%23discussion_r43285767%22%2C%20%22https%3A//github.com/meteor/guide/pull/63%23discussion_r43285860%22%2C%20%22https%3A//github.com/meteor/guide/pull/63%23discussion_r43285985%22%2C%20%22https%3A//github.com/meteor/guide/pull/63%23discussion_r43286160%22%2C%20%22https%3A//github.com/meteor/guide/pull/63%23discussion_r43286270%22%2C%20%22https%3A//github.com/meteor/guide/pull/63%23discussion_r43286325%22%2C%20%22https%3A//github.com/meteor/guide/pull/63%23discussion_r43286364%22%2C%20%22https%3A//github.com/meteor/guide/pull/63%23discussion_r43334831%22%2C%20%22https%3A//github.com/meteor/guide/pull/63%23discussion_r43334845%22%2C%20%22https%3A//github.com/meteor/guide/pull/63%23discussion_r43334938%22%2C%20%22https%3A//github.com/meteor/guide/pull/63%23discussion_r43334961%22%2C%20%22https%3A//github.com/meteor/guide/pull/63%23discussion_r43335025%22%2C%20%22https%3A//github.com/meteor/guide/pull/63%23discussion_r43335955%22%2C%20%22https%3A//github.com/meteor/guide/pull/63%23discussion_r43346939%22%2C%20%22https%3A//github.com/meteor/guide/pull/63%23discussion_r43346969%22%2C%20%22https%3A//github.com/meteor/guide/pull/63%23discussion_r43347306%22%2C%20%22https%3A//github.com/meteor/guide/pull/63%23discussion_r43347307%22%2C%20%22https%3A//github.com/meteor/guide/pull/63%23discussion_r43347308%22%2C%20%22https%3A//github.com/meteor/guide/pull/63%23discussion_r43347309%22%2C%20%22https%3A//github.com/meteor/guide/pull/63%23discussion_r43347310%22%2C%20%22https%3A//github.com/meteor/guide/pull/63%23discussion_r43463728%22%2C%20%22https%3A//github.com/meteor/guide/pull/63%23issuecomment-152373997%22%2C%20%22https%3A//github.com/meteor/guide/pull/63%23discussion_r43465142%22%2C%20%22https%3A//github.com/meteor/guide/pull/63%23discussion_r43465419%22%2C%20%22https%3A//github.com/meteor/guide/pull/63%23discussion_r43465429%22%2C%20%22https%3A//github.com/meteor/guide/pull/63%23issuecomment-152380946%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/63%23issuecomment-152373997%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Did%20another%20pass%20at%20this%2C%20added%20some%20details.%22%2C%20%22created_at%22%3A%20%222015-10-30T01%3A24%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22LGTM%22%2C%20%22created_at%22%3A%20%222015-10-30T01%3A57%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%2033aba7aa46ad533ffdea95133615fb9fd86aa56e%20outlines/data-loading.md%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/63%23discussion_r43217143%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Briding%3F%22%2C%20%22created_at%22%3A%20%222015-10-28T04%3A20%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22Bridging%22%2C%20%22created_at%22%3A%20%222015-10-28T04%3A24%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20guess%20I%27m%20not%20really%20sure%20what%20it%20means%20to%20bridge%20collections%20-%20what%20does%20this%20bullet%20represent%3F%22%2C%20%22created_at%22%3A%20%222015-10-28T04%3A25%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22Oh%2C%20like%20the%20conceptual%20idea%20that%20a%20publication%27s%20purpose%20is%20to%20pump%20data%20from%20a%20server-side%20collection%20into%20the%20client%20side%20collection%20with%20the%20same%20name%20%28typically%29.%20%22%2C%20%22created_at%22%3A%20%222015-10-28T04%3A29%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222015-10-28T17%3A09%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20outlines/data-loading.md%3AL1-34%22%7D%2C%20%22Pull%2033aba7aa46ad533ffdea95133615fb9fd86aa56e%20outlines/data-loading.md%2033%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/63%23discussion_r43286325%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Is%20this%20%60simple%3Arest%60%3F%20Or%20something%20else%3F%20%60http-publish%60%3F%22%2C%20%22created_at%22%3A%20%222015-10-28T17%3A09%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20thought%20it%20was%20%60simple%3Arest%60%22%2C%20%22created_at%22%3A%20%222015-10-29T00%3A00%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-10-29T04%3A09%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20outlines/data-loading.md%3AL1-34%22%7D%2C%20%22Pull%2033aba7aa46ad533ffdea95133615fb9fd86aa56e%20outlines/data-loading.md%2030%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/63%23discussion_r43286270%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20should%20include%20publishing%20transformed%20data%20from%20Mongo%20into%20a%20differently-named%20collection%20on%20the%20client%2C%20to%20emphasize%20some%20strategies%20for%20decoupling%20your%20backend%20data%20model%20from%20your%20frontend%22%2C%20%22created_at%22%3A%20%222015-10-28T17%3A08%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-10-29T04%3A09%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20outlines/data-loading.md%3AL1-34%22%7D%2C%20%22Pull%2033aba7aa46ad533ffdea95133615fb9fd86aa56e%20outlines/data-loading.md%2024%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/63%23discussion_r43285985%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22It%20would%20be%20great%20if%20the%20final%20outline%20had%20a%20list%20of%20the%20misconceptions%20you%20intend%20to%20cover%20here.%22%2C%20%22created_at%22%3A%20%222015-10-28T17%3A06%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22It%27s%20really%20just%20one%20--%20that%20the%20publication%20will%20be%20reactive%20like%20it%20would%20be%20on%20the%20client%20if%20it%20was%20in%20an%20autorun%22%2C%20%22created_at%22%3A%20%222015-10-29T04%3A00%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-10-29T04%3A09%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20outlines/data-loading.md%3AL1-34%22%7D%2C%20%22Pull%2033aba7aa46ad533ffdea95133615fb9fd86aa56e%20outlines/data-loading.md%2016%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/63%23discussion_r43285767%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Is%20this%20about%20how%20subscriptions%20react%20to%20changing%20arguments%20inside%20autoruns%3F%22%2C%20%22created_at%22%3A%20%222015-10-28T17%3A05%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes.%20Sorry%20if%20it%20was%20unclear%2C%20will%20update.%22%2C%20%22created_at%22%3A%20%222015-10-28T23%3A59%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-10-29T04%3A09%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20outlines/data-loading.md%3AL1-34%22%7D%2C%20%22Pull%2033aba7aa46ad533ffdea95133615fb9fd86aa56e%20outlines/data-loading.md%2017%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/63%23discussion_r43285860%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20think%20scoping%20is%20important%20-%20how%20should%20I%20control%20who%20has%20access%20to%20the%20store%27s%20data%3F%22%2C%20%22created_at%22%3A%20%222015-10-28T17%3A05%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27m%20not%20quite%20sure%20what%20you%20mean%20here.%20Do%20you%20mean%20a%20convention%20around%20placing%20stores%20on%20namespaces%20like%20you%20would%20other%20module%20specific%20parts%3F%22%2C%20%22created_at%22%3A%20%222015-10-29T03%3A59%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20outlines/data-loading.md%3AL1-34%22%7D%2C%20%22Pull%2033aba7aa46ad533ffdea95133615fb9fd86aa56e%20outlines/data-loading.md%2028%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/63%23discussion_r43286160%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22If%20this%20is%20actually%20impossible%2C%20do%20we%20need%20a%20code%20item%20for%20this%3F%20I%20bet%20it%20can%27t%20be%20that%20hard%20since%20we%20already%20have%20some%20plumbing%20for%20%60userId%60%22%2C%20%22created_at%22%3A%20%222015-10-28T17%3A07%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22Well%20assuming%20my%20idea%20is%20a%20good%20one%2C%20I%27ll%20leave%20it%20with%20you%20as%20to%20how%20hard%20it%20is%20to%20implement%20my%20solution.%20I%20would%20guess%20low/medium%20difficulty.%22%2C%20%22created_at%22%3A%20%222015-10-29T00%3A00%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22We%20should%20file%20a%20code%20issue%20for%20it%20and%20talk%20there.%22%2C%20%22created_at%22%3A%20%222015-10-29T00%3A01%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22https%3A//github.com/meteor/guide/issues/70%22%2C%20%22created_at%22%3A%20%222015-10-29T00%3A15%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-10-29T04%3A09%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20outlines/data-loading.md%3AL1-34%22%7D%2C%20%22Pull%2033aba7aa46ad533ffdea95133615fb9fd86aa56e%20outlines/data-loading.md%2013%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/63%23discussion_r43285715%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Is%20this%20basically%20saying%2C%20all%20of%20your%20subscriptions%20and%20%60find%60%20calls%20should%20be%20in%20the%20same%20file/right%20next%20to%20each%20other%3F%5Cr%5Cn%5Cr%5CnDo%20we%20have%20any%20strategies%20for%20mitigating%20cross-talk%3F%22%2C%20%22created_at%22%3A%20%222015-10-28T17%3A04%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes%2C%20that%27s%20what%20I%27m%20basically%20saying.%20It%27s%20probably%20not%20a%20hard%20and%20fast%20rule%20%28e.g.%20%60Meteor.user%28%29%60%29%2C%20but%20a%20good%20rule%20of%20thumb.%5Cr%5Cn%5Cr%5CnCross%20talk%20between%20subscriptions%3F%20At%20this%20point%20I%20think%20it%27s%20just%20%5C%22use%20the%20same%20query%20to%20get%20data%20out%20that%20you%20used%20to%20put%20it%20in%5C%22.%20Something%20like%20%40sachag%27s%20package%20would%20obviously%20help%20with%20this.%22%2C%20%22created_at%22%3A%20%222015-10-28T23%3A58%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22PS%20%60cursor-utils%60%20isn%27t%20actually%20a%20real%20thing.%20This%20was%20the%20concept%20of%20being%20able%20to%20do%20something%20like%5Cr%5Cn%5Cr%5Cn%60%60%60%5Cr%5Cnconst%20cursor%20%3D%20Posts.find%28%7BuserId%3A%20..%7D%29%3B%5Cr%5Cnconst%20newCursor%20%3D%20CursorUtils.find%28cursor%2C%20%7Bpublished%3A%20%7B%24gt%3A%20new%20Date%7D%7D%2C%20%7Blimit%3A%203%7D%29%3B%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-10-30T01%3A14%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yeah%20sgtm.%22%2C%20%22created_at%22%3A%20%222015-10-30T01%3A47%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22%2373%22%2C%20%22created_at%22%3A%20%222015-10-30T01%3A54%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222015-10-30T01%3A54%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20outlines/data-loading.md%3AL1-34%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 33aba7aa46ad533ffdea95133615fb9fd86aa56e outlines/data-loading.md 17'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/63#discussion_r43285860'>File: outlines/data-loading.md:L1-34</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> I think scoping is important - how should I control who has access to the store's data?
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> I'm not quite sure what you mean here. Do you mean a convention around placing stores on namespaces like you would other module specific parts?
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/63#issuecomment-152373997'>General Comment</a></b>
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> Did another pass at this, added some details.
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> LGTM
- [x] <a href='#crh-comment-Pull 33aba7aa46ad533ffdea95133615fb9fd86aa56e outlines/data-loading.md 5'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/63#discussion_r43217143'>File: outlines/data-loading.md:L1-34</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Briding?
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> Bridging
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> I guess I'm not really sure what it means to bridge collections - what does this bullet represent?
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> Oh, like the conceptual idea that a publication's purpose is to pump data from a server-side collection into the client side collection with the same name (typically).
- [x] <a href='#crh-comment-Pull 33aba7aa46ad533ffdea95133615fb9fd86aa56e outlines/data-loading.md 13'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/63#discussion_r43285715'>File: outlines/data-loading.md:L1-34</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Is this basically saying, all of your subscriptions and `find` calls should be in the same file/right next to each other?
Do we have any strategies for mitigating cross-talk?
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> Yes, that's what I'm basically saying. It's probably not a hard and fast rule (e.g. `Meteor.user()`), but a good rule of thumb.
Cross talk between subscriptions? At this point I think it's just "use the same query to get data out that you used to put it in". Something like @sachag's package would obviously help with this.
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> PS `cursor-utils` isn't actually a real thing. This was the concept of being able to do something like
```
const cursor = Posts.find({userId: ..});
const newCursor = CursorUtils.find(cursor, {published: {$gt: new Date}}, {limit: 3});
```
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Yeah sgtm.
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> #73
- [x] <a href='#crh-comment-Pull 33aba7aa46ad533ffdea95133615fb9fd86aa56e outlines/data-loading.md 16'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/63#discussion_r43285767'>File: outlines/data-loading.md:L1-34</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Is this about how subscriptions react to changing arguments inside autoruns?
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> Yes. Sorry if it was unclear, will update.
- [x] <a href='#crh-comment-Pull 33aba7aa46ad533ffdea95133615fb9fd86aa56e outlines/data-loading.md 24'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/63#discussion_r43285985'>File: outlines/data-loading.md:L1-34</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> It would be great if the final outline had a list of the misconceptions you intend to cover here.
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> It's really just one -- that the publication will be reactive like it would be on the client if it was in an autorun
- [x] <a href='#crh-comment-Pull 33aba7aa46ad533ffdea95133615fb9fd86aa56e outlines/data-loading.md 28'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/63#discussion_r43286160'>File: outlines/data-loading.md:L1-34</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> If this is actually impossible, do we need a code item for this? I bet it can't be that hard since we already have some plumbing for `userId`
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> Well assuming my idea is a good one, I'll leave it with you as to how hard it is to implement my solution. I would guess low/medium difficulty.
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> We should file a code issue for it and talk there.
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> https://github.com/meteor/guide/issues/70
- [x] <a href='#crh-comment-Pull 33aba7aa46ad533ffdea95133615fb9fd86aa56e outlines/data-loading.md 30'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/63#discussion_r43286270'>File: outlines/data-loading.md:L1-34</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> This should include publishing transformed data from Mongo into a differently-named collection on the client, to emphasize some strategies for decoupling your backend data model from your frontend
- [x] <a href='#crh-comment-Pull 33aba7aa46ad533ffdea95133615fb9fd86aa56e outlines/data-loading.md 33'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/63#discussion_r43286325'>File: outlines/data-loading.md:L1-34</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Is this `simple:rest`? Or something else? `http-publish`?
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> I thought it was `simple:rest`


<a href='https://www.codereviewhub.com/meteor/guide/pull/63?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/meteor/guide/pull/63?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/meteor/guide/pull/63'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>