### PR TITLE
Blaze outline

### DIFF
--- a/outlines/blaze.md
+++ b/outlines/blaze.md
@@ -13,7 +13,8 @@
     1. `{{#if/unless}}`
     2. `{{#each .. in ..}}`
     3. `{{#let}}`
-      1. NOTE: we need to ensure that issues around lexical scope and event handlers are resolved before we fail to even mention `{{#each}}` and `{{#with}}`. But we should attempt it.
+    4. Explain `{{#each}}` and `{{#with}}`, indicate that it's better not to use them.
+      1. NOTE: we need to ensure that issues around lexical scope and event handlers are resolved for `{{#each .. in ..}}` and `{{#let}}`.
   10. Comments
   11. Strictness
   12. Escaping
@@ -22,7 +23,7 @@
   2. Always set data contexts to `{name: doc}` rather than just `doc`. Always set a d.c on an inclusion.
   3. Use `{{#each .. in .. }}` to achieve the above
   4. Use the template instance as a component -- adding a `{{instance}}` helper to access it
-  5. Use a (named / scoped on _id if possible) reactive dict for instance state
+  5. Use a (named / scoped on `_id` if possible) reactive dict for instance state
   6. Attach functions to the template instance (in `onCreated`) to sensibly modify state
   7. Place `const template = Template.instance()` at the top of all helpers that care about state
   8. Always scope DOM lookups with `this.$`
@@ -44,6 +45,7 @@
   2. When does a helper-rerun? (when its data context or reactive deps change)
     1. So be careful, this can happen a lot! If your helper is expensive, consider something like https://github.com/peerlibrary/meteor-computed-field
   3. How does an each tag re-run / decide when new data should appear?
+    1. How does the `{{attrs}` syntax work, some tricks on how to use it.
   4. How do name lookups work?
   5. What does the build system do exactly?
   6. What is a view?

--- a/outlines/blaze.md
+++ b/outlines/blaze.md
@@ -2,10 +2,24 @@
 
 1. Introduction to Blaze -- the tracker-backed handlebars like templating syntax
   1. Example of spacebars syntax, data context + helpers
-  2. Hmmm. this is basically just the exact content of https://github.com/meteor/meteor/blob/devel/packages/spacebars/README.md#each I'm tempted to more or less just work through this verbatim for the first few sections. (sans the complicated stuff)
+  2. Data contexts and access - name lookup (`.`, `this`, `..`, `[0]`), and null values
+  3. Helpers, arguments, options
+  4. Inclusion of other templates + arguments, passing data contexts
+  5. Helpers inside tags -- returning strings and objects, `checked={{isChecked}}`
+  6. Nested helpers + sub expressions
+  7. Block helpers (you can create them with templates, see 10. below)
+  8. Safestrings and `{{{`
+  9. Builtin block helpers
+    1. `{{#if/unless}}`
+    2. `{{#with}}`
+    3. `{{#each}}`
+    3. `{{#let}}`
+  10. Comments
+  11. Strictness
+  12. Escaping
 2. Creating reusable "pure" components with Blaze / best practice (a lot of this is repeating @sanjo's boilerplate)
   1. Validating data context fits a schema
-  2. Always set data contexts to `{name: doc}` rather than just `doc`
+  2. Always set data contexts to `{name: doc}` rather than just `doc`. Always set a d.c on an inclusion.
   3. Use `{{#each .. in .. }}` to achieve the above
   4. Use the template instance as a component -- adding a `{{template}}` helper to access it
   5. Use a (named / scoped on _id if possible) reactive dict for instance state

--- a/outlines/blaze.md
+++ b/outlines/blaze.md
@@ -25,7 +25,7 @@
   4. Use the template instance as a component -- adding a `{{instance}}` helper to access it
   5. Use a (named / scoped on `_id` if possible) reactive dict for instance state
   6. Attach functions to the template instance (in `onCreated`) to sensibly modify state
-  7. Place `const template = Template.instance()` at the top of all helpers that care about state
+  7. Place `const instance = Template.instance()` at the top of all helpers/event handlers that care about state
   8. Always scope DOM lookups with `this.$`
   9. Use `.js-X` in event maps
   10. Pass extra content to components with `Template.contentBlock`, or named template arguments

--- a/outlines/blaze.md
+++ b/outlines/blaze.md
@@ -1,6 +1,6 @@
 # Blaze
 
-1. Introduction to Blaze -- the tracker-backed handlebars like templating syntax
+1. Introduction to Spacebars -- the tracker-backed handlebars like templating syntax
   1. Example of spacebars syntax, data context + helpers
   2. Data contexts and access - name lookup (`.`, `this`, `..`, `[0]`), and null values
   3. Helpers, arguments, options
@@ -11,9 +11,9 @@
   8. Safestrings and `{{{`
   9. Builtin block helpers
     1. `{{#if/unless}}`
-    2. `{{#with}}`
-    3. `{{#each}}`
+    2. `{{#each .. in ..}}`
     3. `{{#let}}`
+      1. NOTE: we need to ensure that issues around lexical scope and event handlers are resolved before we fail to even mention `{{#each}}` and `{{#with}}`. But we should attempt it.
   10. Comments
   11. Strictness
   12. Escaping
@@ -21,7 +21,7 @@
   1. Validating data context fits a schema
   2. Always set data contexts to `{name: doc}` rather than just `doc`. Always set a d.c on an inclusion.
   3. Use `{{#each .. in .. }}` to achieve the above
-  4. Use the template instance as a component -- adding a `{{template}}` helper to access it
+  4. Use the template instance as a component -- adding a `{{instance}}` helper to access it
   5. Use a (named / scoped on _id if possible) reactive dict for instance state
   6. Attach functions to the template instance (in `onCreated`) to sensibly modify state
   7. Place `const template = Template.instance()` at the top of all helpers that care about state
@@ -29,10 +29,12 @@
   9. Use `.js-X` in event maps
   10. Pass extra content to components with `Template.contentBlock`, or named template arguments
   11. Use the `onRendered` callback to integrate w/ 3rd party libraries
+    1. Waiting on subscriptions w/ `autorun` pattern: https://github.com/meteor/guide/pull/75/files#r43545240
 3. Writing "smart" components with Blaze
   1. All of section 2.
   2. Use `this.autorun` and `this.subscribe`, listening to `FlowRouter` and `this.state`
   3. Set up cursors in helpers to be passed into pure sub-components, and filtered with `cursor-utils`
+    1. Why cursors are preferred to arrays.
   4. Access stores directly from helpers.
 4. Reusing code between templates
   1. Prefer utilities/composition to mixins or inheritance

--- a/outlines/blaze.md
+++ b/outlines/blaze.md
@@ -1,0 +1,42 @@
+# Blaze
+
+1. Introduction to Blaze -- the tracker-backed handlebars like templating syntax
+  1. Example of spacebars syntax, data context + helpers
+  2. Hmmm. this is basically just the exact content of https://github.com/meteor/meteor/blob/devel/packages/spacebars/README.md#each I'm tempted to more or less just work through this verbatim for the first few sections. (sans the complicated stuff)
+2. Creating reusable "pure" components with Blaze / best practice (a lot of this is repeating @sanjo's boilerplate)
+  1. Validating data context fits a schema
+  2. Always set data contexts to `{name: doc}` rather than just `doc`
+  3. Use `{{#each .. in .. }}` to achieve the above
+  4. Use the template instance as a component -- adding a `{{template}}` helper to access it
+  5. Use a (named / scoped on _id if possible) reactive dict for instance state
+  6. Attach functions to the template instance (in `onCreated`) to sensibly modify state
+  7. Place `const template = Template.instance()` at the top of all helpers that care about state
+  8. Always scope DOM lookups with `this.$`
+  9. Use `.js-X` in event maps
+  10. Pass extra content to components with `Template.contentBlock`, or named template arguments
+  11. Use the `onRendered` callback to integrate w/ 3rd party libraries
+3. Writing "smart" components with Blaze
+  1. All of section 2.
+  2. Use `this.autorun` and `this.subscribe`, listening to `FlowRouter` and `this.state`
+  3. Set up cursors in helpers to be passed into pure sub-components, and filtered with `cursor-utils`
+  4. Access stores directly from helpers.
+4. Reusing code between templates
+  1. Prefer utilities/composition to mixins or inheritance
+  2. How to write global helpers
+5. Understanding Blaze
+  1. When does a template re-render (when its data context changes)
+  2. When does a helper-rerun? (when its data context or reactive deps change)
+    1. So be careful, this can happen a lot! If your helper is expensive, consider something like https://github.com/peerlibrary/meteor-computed-field
+  3. How does an each tag re-run / decide when new data should appear?
+  4. How do name lookups work?
+  5. What does the build system do exactly?
+  6. What is a view?
+6. Testing Blaze templates
+  1. Rendering a template in a unit test
+  2. Querying the DOM (general but just a pointer here)
+  3. Triggering reactivity and waiting for re-rendering
+  4. Simulating events w/ JQ
+7. Useful Blaze utilities / other approaches
+  1. https://github.com/peerlibrary/meteor-blaze-components
+  2. https://github.com/raix/Meteor-handlebar-helpers
+  3. Much, much more...


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43474487%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43528704%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43528778%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43528860%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43529025%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43529277%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43529425%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43529436%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43529511%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43542521%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43542591%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43542682%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43542799%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43542831%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43542851%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43543081%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43543307%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43543830%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43544764%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43544956%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43545240%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43545430%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43545519%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43546015%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43546258%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43547042%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43547308%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43547371%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43547460%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43547983%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43548074%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43548156%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43551817%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43552039%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43552126%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43552188%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43552532%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43553820%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43567370%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43567391%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43567399%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43567503%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43567504%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43567506%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43567508%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43567511%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43567517%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43567545%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43567562%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43567569%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43567601%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43567603%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43567619%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43567621%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43567629%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43567631%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43567633%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43567634%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43567641%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43567657%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43567659%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43568728%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43568738%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43568745%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43568751%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43568805%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43568818%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43568827%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43568853%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43569147%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43594840%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43594882%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43594919%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43594931%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43594978%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43594982%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43595019%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43595023%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43595094%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43595170%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43595200%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43595201%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43595249%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43595275%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43595428%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43595544%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43595545%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43595843%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43598023%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43707980%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43708037%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43708044%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43709933%22%2C%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43710208%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%20d2231762773ac2dd73c8502c4004691d4c48def9%20outlines/blaze.md%2024%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43542682%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Or%20%60instance%60%3F%22%2C%20%22created_at%22%3A%20%222015-10-30T19%3A25%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/585279%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mitar%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yeah%2C%20I%20think%20we%20should%20add%20some%20official%20naming%20here%20-%20for%20example%20%5C%22template%20class%5C%22%20and%20%5C%22template%20instance%5C%22%3F%22%2C%20%22created_at%22%3A%20%222015-10-30T19%3A27%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22That%20would%20be%20the%20obvious%20one.%20I%27ll%20switch%20this%20to%20%60%7B%7Binstance%7D%7D%60%20as%20it%27s%20clearer%20and%20I%20think%20what%20most%20people%20are%20doing%20anyway.%22%2C%20%22created_at%22%3A%20%222015-10-31T03%3A21%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-10-31T03%3A21%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20outlines/blaze.md%3AL1-57%22%7D%2C%20%22Pull%20d2231762773ac2dd73c8502c4004691d4c48def9%20outlines/blaze.md%2025%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43529025%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Do%20we%20know%20if%20this%20actually%20works%20with%20hot%20code%20push%3F%20I%27m%20not%20sure%20that%20just%20adding%20the%20ID%20will%20cut%20it%3F%22%2C%20%22created_at%22%3A%20%222015-10-30T17%3A26%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20think%20better%20then%20attaching%20reactive%20dict%20is%20to%20simply%20attach%20%5Breactive%20field%5D%28https%3A//github.com/peerlibrary/meteor-reactive-field%29%20or%20%5Bcomputed%20field%5D%28https%3A//github.com/peerlibrary/meteor-computed-field%29.%5Cr%5Cn%5Cr%5CnThen%20you%20can%20do%20things%20like%3A%5Cr%5Cn%5Cr%5Cn%60%60%60javascript%5Cr%5CnonCreated%3A%20function%20%28%29%20%7B%5Cr%5Cn%20%20this.foo%20%3D%20new%20ReactiveField%2842%29%3B%5Cr%5Cn%7D%5Cr%5Cn%60%60%60%5Cr%5Cn%5Cr%5CnAnd%20in%20the%20template%3A%5Cr%5Cn%5Cr%5Cn%60%60%60%5Cr%5Cn%7B%7Binstance.foo%7D%7D%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-10-30T19%3A27%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/585279%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mitar%22%7D%7D%2C%20%7B%22body%22%3A%20%22Curious%20why%20you%20chose%20the%20name%20%5C%22field%5C%22%20for%20those%3F%20Rather%20than%20property%2C%20value%2C%20etc%3F%22%2C%20%22created_at%22%3A%20%222015-10-30T19%3A29%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hm%2C%20no%20particular%20reason.%20%3A-%29%20Field%20is%20something%20which%20is%20more%20used%20in%20MongoDB%20context%2C%20over%20property.%20Less%20characters%20to%20type.%20I%20didn%27t%20use%20value%20because%20the%20primary%20use%20case%20was%20with%20components%20for%20me.%5Cr%5Cn%5Cr%5CnBut%20yea%2C%20it%20is%20not%20necessary%20the%20best%20naming.%20%3B-%29%22%2C%20%22created_at%22%3A%20%222015-10-30T19%3A48%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/585279%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mitar%22%7D%7D%2C%20%7B%22body%22%3A%20%22So%20a%20reactive%20field%20is%20sugar%20around%20%60ReactiveVar%60%3F%20That%27s%20nice%20--%20I%20can%20get%20behind%20it.%5Cr%5Cn%5Cr%5CnYes%2C%20a%20reactive-dict%20works%20as%20advertised%20%28exercise%20for%20the%20reader%2C%20update%20the%20scaffolded%20app%20to%20not%20use%20the%20%60Session%60%2C%20it%27s%20like%20a%20million%20times%20better%20and%20embarrassing%20that%20we%20haven%27t%20already%20done%20this%29.%22%2C%20%22created_at%22%3A%20%222015-10-31T03%3A27%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22So%2C%20I%27d%20still%20recommend%20a%20dict%20as%20the%20%5C%22default%5C%22%20to%20start%20with%20%28hint%20hint%20should%20just%20be%20a%20part%20of%20all%20templates%20without%20any%20work%29%2C%20as%3A%5Cr%5Cn%5Cr%5Cn1.%20HCR-niceness%5Cr%5Cn2.%20Can%20store%20more%20than%20one%20thing%2C%20which%20you%20usually%20want%5Cr%5Cn3.%20You%20can%20still%20write%20%60%7B%7Binstance.state.get%20%27counter%27%7D%7D%60.%22%2C%20%22created_at%22%3A%20%222015-10-31T03%3A31%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40stubailo%20agree%3F%22%2C%20%22created_at%22%3A%20%222015-10-31T03%3A31%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hm%2C%20I%20really%20think%20we%20should%20not%20make%20it%20be%20a%20part%20of%20template%20instance%20just%20so.%20We%20have%20too%20many%20places%20where%20people%20can%20store%20then%20stuff%2C%20into%20%60state%60%2C%20into%20template%20instance%2C%20into%20data%20context.%20Too%20many%20choices%20then%20mean%20people%20will%20be%20confused%20where%20to%20store%20it%2C%20and%20some%20people%20will%20use%20something%2C%20other%20something%20else%20so%20things%20will%20be%20less%20interoperable.%5Cr%5Cn%5Cr%5CnI%20really%20think%20that%20%60%7B%7Binstance.counter%7D%7D%60%20is%20much%20nicer%20than%20%60%7B%7Binstance.state.get%20%27counter%27%7D%7D%60.%20Moreover%2C%20it%20allows%20you%20to%20have%20multiple%20stuff%20attached%20to%20%60instance%60.%20Like%20computer%20field%2C%20or%20simply%20a%20method/function.%20And%20you%20can%20then%20call%20all%20in%20the%20same%20way%2C%20with%20%60instance.something%60.%20Otherwise%20you%20have%20some%20stuff%20in%20%60state%60%2C%20some%20stuff%20in%20data%20context%2C%20some%20stuff%20as%20a%20method%2C%20some%20stuff%20as%20a%20computed%20field.%5Cr%5Cn%5Cr%5CnI%20really%20think%20this%20is%20bad%20design.%20There%20is%20no%20need%20for%20this.%20While%20my%20other%20comments%20are%20just%20%20comments%2C%20here%20I%20really%20think%20strongly%20that%20the%20best%20thing%20is%20just%20to%20encourage%20use%20of%20template%20instances%20without%20any%20need%20for%20extra%20sub-namespacing%20into%20%60state%60.%22%2C%20%22created_at%22%3A%20%222015-10-31T06%3A25%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/585279%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mitar%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20advantage%20of%20having%20a%20single%20point%20to%20store%20state%20is%20that%20it%20allows%20the%20system%20to%20do%20things%20for%20you.%5Cr%5Cn%5Cr%5CnAuto-migration%20on%20HCR%20is%20a%20big%20advantage%20that%20we%20see%20already%20here%2C%20but%20another%20is%20extra%20APIs%20like%20the%20equivalent%20of%20%60shouldComponentUpdate%28nextProps%2C%20nextState%29%60.%20This%20becomes%20a%20lot%20trickier%20if%20things%20are%20adhoc.%5Cr%5Cn%5Cr%5CnTo%20your%20point%20on%20where%20people%20should%20store%20things%2C%20I%20think%20it%27s%20simple%20--%20in%20the%20data%20if%20it%27s%20an%20argument%20%28i.e.%20coming%20down%20the%20component%20heirarchy%29%2C%20in%20the%20state%20if%20it%27s%20state%20that%27s%20relevant%20to%20this%20component%20%28and%20it%27s%20children%2C%20potentially%29.%5Cr%5Cn%5Cr%5CnWhere%20it%20doesn%27t%20quite%20make%20sense%20is%20if%20you%20want%20to%20store%20something%20more%20complex%20than%20a%20serializable%20attribute%20--%20for%20instance%20a%20computed%20field%20or%20a%20local%20collection.%20I%20don%27t%20have%20a%20good%20answer%20to%20this%20yet...%22%2C%20%22created_at%22%3A%20%222015-11-02T03%3A45%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3E%20Auto-migration%20on%20HCR%20is%20a%20big%20advantage%20that%20we%20see%20already%20here%5Cr%5Cn%5Cr%5CnBut%20that%20could%20also%20be%20made%20automatically%20in%20the%20background%3F%20It%20is%20not%20so%20hard%20to%20go%20over%20all%20properties%20of%20a%20template%20instance%20and%20see%20which%20are%20reactive%20fields%20and%20have%20some%20interface%20to%20serialize%20and%20deserialize%20and%20stuff%20like%20that%3F%22%2C%20%22created_at%22%3A%20%222015-11-02T04%3A01%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/585279%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mitar%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20outlines/blaze.md%3AL1-57%22%7D%2C%20%22Pull%20d2231762773ac2dd73c8502c4004691d4c48def9%20outlines/blaze.md%2026%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43544956%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Using%20reactive%20field%20you%20get%20that%20for%20free.%20%3A-%29%5Cr%5Cn%5Cr%5Cn%60%60%60%5Cr%5Cntemplate.onCreated%28function%20%28%29%20%7B%5Cr%5Cn%20%20this.foo%20%3D%20new%20ReactiveField%2842%29%3B%5Cr%5Cn%7D%29%3B%5Cr%5Cntemplate.events%28%7B%5Cr%5Cn%20%20%27click%20button%27%3A%20function%20%28event%2C%20instance%29%20%7B%5Cr%5Cn%20%20%20%20instance.foo%28%24%28event.currentTarget%29.val%28%29%29%3B%5Cr%5Cn%20%20%7D%5Cr%5Cn%7D%29%3B%5Cr%5Cn%60%60%60%5Cr%5Cn%60%60%60%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-10-30T19%3A49%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/585279%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mitar%22%7D%7D%2C%20%7B%22body%22%3A%20%22Oh%20right%2C%20but%20I%20mean%20complicated%20state%20changes%20that%20shouldn%27t%20be%20in%20the%20event%20handler.%20Like%5Cr%5Cn%5Cr%5Cn%60%60%60js%5Cr%5CnTemplate.X.onCreated%28function%28%29%20%7B%5Cr%5Cn%20%20this.updateFoo%20%3D%20%28input%29%20%3D%3E%20%7B%5Cr%5Cn%20%20%20%20const%20newValue%20%3D%20do%20%2A%20something%20%2B%20complicated%20/%20with%20%2A%20foo%3B%5Cr%5Cn%20%20%20%20this.state.set%28%27foo%27%2C%20newValue%29%3B%5Cr%5Cn%20%20%7D%5Cr%5Cn%7D%29%3B%5Cr%5Cn%5Cr%5CnTemplate.X.events%28%7B%5Cr%5Cn%20%20%27click%20button%27%3A%20function%28event%2C%20instance%29%20%7B%5Cr%5Cn%20%20%20%20instance.updateFoo%28event.target.value%29%3B%5Cr%5Cn%20%20%7D%5Cr%5Cn%7D%29%3B%22%2C%20%22created_at%22%3A%20%222015-10-31T03%3A34%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222015-10-31T03%3A34%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22Exactly.%20That%20is%20what%20we%20even%20suggest%20in%20Blaze%20Components.%20That%20event%20maps%20should%20map%20between%20selectors%20and%20methods%20and%20then%20all%20event%20handling%20should%20be%20in%20methods.%20Then%20you%20can%20extend%20those%20methods%20in%20child%20classes.%20And%20then%20it%20is%20really%20cool%20when%3A%5Cr%5Cn%5Cr%5Cn%60%60%60%5Cr%5Cn%20%20this.updateFoo%20%3D%20%28input%29%20%3D%3E%20%7B%5Cr%5Cn%20%20%20%20const%20newValue%20%3D%20do%20%2A%20something%20%2B%20complicated%20/%20with%20%2A%20this.foo%28%29%3B%5Cr%5Cn%20%20%20%20this.foo%28newValue%29%3B%5Cr%5Cn%20%20%7D%5Cr%5Cn%60%60%60%5Cr%5Cn%5Cr%5CnSo%20that%20you%20can%20access%20reactive%20fields%20as%20you%20would%20access%20some%20other%20method%20or%20property%20on%20template%20instance.%20This%20is%20a%20really%20powerful%20pattern.%22%2C%20%22created_at%22%3A%20%222015-10-31T06%3A27%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/585279%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mitar%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-02T03%3A38%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20outlines/blaze.md%3AL1-57%22%7D%2C%20%22Pull%20d2231762773ac2dd73c8502c4004691d4c48def9%20outlines/blaze.md%2021%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43542521%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Also%2C%20what%20about%20uses%20models%20and%20instances%20of%20models%20for%20data%20contexts%3F%20This%20works%20for%20us%20very%20well.%20Then%20you%20can%20just%20do%20%60instanceof%60%20checks%20if%20you%20really%20want.%22%2C%20%22created_at%22%3A%20%222015-10-30T19%3A23%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/585279%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mitar%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20think%20SS%20allows%20you%20to%20do%20%60instanceof%60%20checks%20in%20a%20straightforward%20way%2C%20no%3F%22%2C%20%22created_at%22%3A%20%222015-10-31T03%3A20%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-10-31T03%3A20%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22SS%3F%20And%20easy%20checking%20was%20not%20the%20point.%20The%20point%20is%20to%20suggest%20to%20people%20to%20maybe%20consider%20using%20high-level%20objects%20as%20data%20contexts.%20So%20to%20describe%20%28it%20is%20a%20guide%29%20a%20pattern%20where%20you%20use%20%60transform%60%20to%20transform%20your%20document%20from%20database%2C%20and%20then%20you%20use%20%60instanceof%60%20to%20find%20it.%22%2C%20%22created_at%22%3A%20%222015-10-31T06%3A17%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/585279%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mitar%22%7D%7D%2C%20%7B%22body%22%3A%20%22Simple%20Schema.%5Cr%5Cn%5Cr%5CnWe%20are%20going%20to%20describe%20that%20pattern%20%28see%20collections%20article%20%2B%20helpers%29.%22%2C%20%22created_at%22%3A%20%222015-11-02T03%3A24%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22OK.%5Cr%5Cn%5Cr%5CnBTW%2C%20we%20should%20consider%20also%20something%20about%20JSON%20schema%2C%20a%20standard.%20Simple%20Schema%20is%20great%2C%20but%20it%20is%20not%20inter-operable%20with%20others.%20Not%20that%20we%20should%20do%20something%20about%20this%20now%2C%20but%20in%20the%20longer%20term%20it%20would%20be%20great%20if%20our%20publish%20functions/mongo%20collection%20would%20have%20JSON%20schema%20associated%20with%20it%20%28then%20also%20EJSON%20would%20be%20simpler%29.%22%2C%20%22created_at%22%3A%20%222015-11-02T03%3A26%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/585279%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mitar%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-02T03%3A29%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20outlines/blaze.md%3AL1-57%22%7D%2C%20%22Pull%20c5b034e4dad8ba662d32f972bf41ba4cf80cae53%20outlines/blaze.md%2027%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43568745%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Let%27s%20do%20%60instance%20%3D%20Template.instance%28%29%60%20here%20as%20well.%22%2C%20%22created_at%22%3A%20%222015-10-31T06%3A19%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/585279%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mitar%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yeah%2C%20I%27m%20inclined%20to%20agree.%20My%20only%20hesitancy%20would%20be%20that%20in%20all%20documentation%20ever%20you%20find%20on%20the%20web%20you%27ll%20see%20%60function%28event%2C%20template%29%60%20in%20event%20handlers.%20We%20are%20now%20saying%20you%20should%20write%20%60function%28event%2C%20instance%29%60%20I%20guess.%20%5Cr%5Cn%5Cr%5Cn%40stubailo%20what%20do%20you%20think%3F%22%2C%20%22created_at%22%3A%20%222015-11-02T03%3A26%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20think%20it%27s%20not%20a%20big%20deal.%20I%27d%20obviously%20prefer%20%60this%60%2C%20but%20%60instance%60%20or%20%60self%60%20would%20be%20second%20best.%20The%20word%20%60template%60%20is%20over-used%2C%20who%20knows%20what%20it%20refers%20to.%22%2C%20%22created_at%22%3A%20%222015-11-03T01%3A33%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20think%20we%20just%20need%20to%20be%20consistent%20across%20template%20access%2C%20event%20handlers%20and%20helpers.%20I%20think%20%60instance%60%20works%20best%20for%20those%20three%20so%20we%27ll%20run%20with%20it.%22%2C%20%22created_at%22%3A%20%222015-11-03T02%3A09%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-03T02%3A15%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20outlines/blaze.md%3AL1-59%22%7D%2C%20%22Pull%20d2231762773ac2dd73c8502c4004691d4c48def9%20outlines/blaze.md%2031%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43545240%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Maybe%20document%20wait%20for%20subscription%20to%20finish%20pattern%20I%20have%20to%20use%20regularly%3A%5Cr%5Cn%5Cr%5Cn%60%60%60%5Cr%5CnonRendered%28function%20%28%29%5Cr%5Cn%20%20const%20instance%20%3D%20Template.instance%28%29%3B%5Cr%5Cn%20%20this.autorun%28function%20%28computation%29%20%7B%5Cr%5Cn%20%20%20%20if%20%28%21instance.subscriptionsReady%28%29%29%20return%3B%5Cr%5Cn%20%20%20%20computation.stop%28%29%3B%5Cr%5Cn%20%20%20%20%5Cr%5Cn%20%20%20%20//%20Use%203rd%20party%20stuff%20to%20render%20now%20something.%5Cr%5Cn%20%20%7D%29%3B%5Cr%5Cn%7D%29%3B%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-10-30T19%3A52%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/585279%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mitar%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yeah%2C%20this%20is%20an%20unfortunate%20pattern%2C%20we%20should%20add%20it%20here.%20lol%22%2C%20%22created_at%22%3A%20%222015-10-30T20%3A03%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22Talking%20about%20promises%2C%20this%20is%20one%20very%20common%20pattern%20I%20am%20using%20and%20I%20have%20not%20yet%20made%20a%20package%20for%20it.%20This%20wait%20for%20condition%20and%20stop%20autoruns.%22%2C%20%22created_at%22%3A%20%222015-10-30T20%3A15%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/585279%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mitar%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20am%20using%20it%20a%20lot%20for%20inter-component%20communication%3A%20https%3A//github.com/peerlibrary/meteor-blaze-components/issues/82%20But%20I%20have%20not%20yet%20found%20a%20good%20name%20or%20API%20for%20it.%22%2C%20%22created_at%22%3A%20%222015-10-30T20%3A15%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/585279%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mitar%22%7D%7D%2C%20%7B%22body%22%3A%20%22Good%20one%2C%20thanks%20%40mitar%20%22%2C%20%22created_at%22%3A%20%222015-10-31T03%3A36%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-10-31T03%3A36%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22%28PS%20this%20is%20exactly%20the%20sort%20of%20kludge%20that%20I%20think%20should%20make%20it%20into%20the%20guide%20..%20%3B%29%20%29%22%2C%20%22created_at%22%3A%20%222015-10-31T03%3A38%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B%22%2C%20%22created_at%22%3A%20%222015-10-31T03%3A39%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-10-31T03%3A40%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22If%20you%20help%20me%20find%20a%20good%20API%20for%20this%2C%20I%20can%20maybe%20make%20a%20package%20which%20wraps%20it%20up.%20Like%20%60AutorunPromise%60%3F%20%3A-%29%20Or%20%60Tracker.wait%60%3F%20Like%20%60Tracker.wait%28condition%2C%20body%29%60%3F%22%2C%20%22created_at%22%3A%20%222015-10-31T06%3A20%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/585279%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mitar%22%7D%7D%2C%20%7B%22body%22%3A%20%22Note%20to%20myself%2C%20improved%3A%5Cr%5Cn%5Cr%5Cn%60%60%60%5Cr%5CnonRendered%28function%20%28%29%5Cr%5Cn%20%20const%20instance%20%3D%20this%3B%5Cr%5Cn%20%20this.autorun%28function%20%28computation%29%20%7B%5Cr%5Cn%20%20%20%20if%20%28%21instance.subscriptionsReady%28%29%29%20return%3B%5Cr%5Cn%20%20%20%20computation.stop%28%29%3B%5Cr%5Cn%5Cr%5Cn%20%20%20%20Tracker.nonreactive%28function%20%28%29%20%7B%5Cr%5Cn%20%20%20%20%20%20//%20Use%203rd%20party%20stuff%20to%20render%20now%20something.%5Cr%5Cn%20%20%20%20%7D%29%3B%5Cr%5Cn%20%20%7D%29%3B%5Cr%5Cn%7D%29%3B%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-10-31T07%3A21%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/585279%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mitar%22%7D%7D%2C%20%7B%22body%22%3A%20%22Lol.%20Circa%202012%3A%20https%3A//github.com/tmeasday/meteor-deps-extensions%23await%22%2C%20%22created_at%22%3A%20%222015-11-02T03%3A27%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-02T03%3A27%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22So%2C%20should%20I%20make%20a%20package%20only%20for%20this%20or%20what%3F%20%3A-%29%5Cr%5Cn%5Cr%5CnBTW%2C%20I%20am%20starting%20to%20think%20that%20this%20could%20also%20be%20combined%20with%20promises.%20I%20will%20wrote%20more%20into%20the%20ticket%20about%20promises.%22%2C%20%22created_at%22%3A%20%222015-11-02T03%3A35%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/585279%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mitar%22%7D%7D%2C%20%7B%22body%22%3A%20%22Well%20I%20think%20a%20%60tracker-extensions%60%20package%20is%20probably%20a%20pretty%20handy%20thing%20if%20stuff%20can%20be%20built%20without%20needing%20changes%20to%20core.%20Please%20take%20anything%20from%20my%20old%20deps-extension%20package%20that%20is%20still%20relevant%20if%20you%20do%20end%20up%20making%20the%20package%2C%20and%20let%20me%20know%20if%20you%20make%20the%20package.%22%2C%20%22created_at%22%3A%20%222015-11-02T03%3A49%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-02T03%3A49%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20outlines/blaze.md%3AL1-57%22%7D%2C%20%22Pull%20d2231762773ac2dd73c8502c4004691d4c48def9%20outlines/blaze.md%2035%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43529277%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Perhaps%20mention%20how%20cursors%20are%20better%20than%20arrays%20when%20working%20with%20Blaze%22%2C%20%22created_at%22%3A%20%222015-10-30T17%3A28%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22What%20are%20cursor-utils%3F%22%2C%20%22created_at%22%3A%20%222015-10-30T19%3A55%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/585279%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mitar%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40mitar%20https%3A//github.com/meteor/guide/issues/73%22%2C%20%22created_at%22%3A%20%222015-10-31T03%3A37%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40stubailo%20yup%22%2C%20%22created_at%22%3A%20%222015-10-31T03%3A37%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222015-10-31T03%3A37%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20outlines/blaze.md%3AL1-57%22%7D%2C%20%22Pull%20d2231762773ac2dd73c8502c4004691d4c48def9%20outlines/blaze.md%203%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43474487%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Technically%2C%20the%20syntax%20is%20called%20spacebars%2C%20and%20the%20runtime%20is%20blaze.%20Like%20jsx%20and%20react.%22%2C%20%22created_at%22%3A%20%222015-10-30T06%3A13%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22Speaking%20of%20Tracker%2C%20where%20do%20we%20cover%20that%20in%20the%20guide%3F%3F%22%2C%20%22created_at%22%3A%20%222015-10-30T17%3A30%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hmm.%20No%2C%20we%20don%27t%20explicitly.%20I%20guess%20it%20is%20bigger%20than%20Blaze%20%28you%20should%20know%20about%20how%20it%20works%20in%20the%20React%20world%20too%29.%20Does%20it%20deserve%20it%27s%20own%20%28shorter%29%20article%3F%22%2C%20%22created_at%22%3A%20%222015-10-31T03%3A05%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22https%3A//github.com/meteor/guide/issues/77%22%2C%20%22created_at%22%3A%20%222015-10-31T03%3A06%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222015-10-31T03%3A06%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20outlines/blaze.md%3AL1-57%22%7D%2C%20%22Pull%20d2231762773ac2dd73c8502c4004691d4c48def9%20outlines/blaze.md%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43528704%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20think%20in%20this%20guide%2C%20we%20should%20go%20into%20detail%20about%20data%20context%20and%20how%20it%20relates%20to%20%5C%22Views%5C%22%20-%20we%20gloss%20over%20this%20in%20the%20intro%20tutorial%20completely.%22%2C%20%22created_at%22%3A%20%222015-10-30T17%3A23%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22However%2C%20there%20is%20now%20a%20world%20in%20which%20you%20could%20use%20Blaze%20without%20data%20context%20entirely%21%20We%20could%20see%20what%20that%20looks%20like.%22%2C%20%22created_at%22%3A%20%222015-10-30T17%3A25%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ah%2C%20I%20see%20you%20have%20this%20in%20an%20explanation%20below.%22%2C%20%22created_at%22%3A%20%222015-10-30T17%3A29%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-10-30T17%3A29%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20outlines/blaze.md%3AL1-57%22%7D%2C%20%22Pull%20d2231762773ac2dd73c8502c4004691d4c48def9%20outlines/blaze.md%2044%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43545430%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22And%20attributes%20how%20are%20they%20changed%3F%22%2C%20%22created_at%22%3A%20%222015-10-30T19%3A54%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/585279%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mitar%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40mitar%20I%27m%20not%20quite%20sure%20what%20you%20mean%20here%3F%22%2C%20%22created_at%22%3A%20%222015-10-31T03%3A37%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22So%20DOM%20element%20attributes.%20Things%20like%20%60%3Cdiv%20%7B%7Battrs%7D%7D%3E%60.%20So%20we%20should%20explain%20how%20do%20they%20reactivelly%20change%20as%20well%2C%20no%3F%5Cr%5Cn%5Cr%5CnBTW%2C%20with%20Blaze%20Components%20there%20is%20also%20a%20nice%20pattern%20which%20emerged%20for%20attributes.%20Namely%20that%20you%20can%20have%20multiple%20sources%20contribute%20to%20the%20same%20dict%20which%20you%20then%20render%20out.%20Like%20a%20dict%20of%20CSS%20classes%2C%20and%20inline%20style%2C%20and%20then%20you%20render%20them%20at%20once%20out.%20Instead%20of%20patching%20them%20together%20in%20templates.%20With%20inheritance%20and%20mixins%20you%20can%20do%20this%20really%20well.%22%2C%20%22created_at%22%3A%20%222015-10-31T06%3A30%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/585279%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mitar%22%7D%7D%2C%20%7B%22body%22%3A%20%22Then%20you%20can%20have%20a%20simple%20helper%20like%3A%5Cr%5Cn%5Cr%5Cn%60%60%60%5Cr%5Cn%5Cr%5Cn%20%20%23%20Converts%20an%20array%20of%20style%20classes%20into%20a%20class%20attribute.%20It%20doesn%27t%20return%20anything%5Cr%5Cn%20%20%23%20if%20the%20array%20is%20empty%20%28or%20null%29%20so%20that%20class%20attribute%20is%20not%20unnecessarily%20created.%5Cr%5Cn%20%20class%3A%20%28styleClassesArray%29%20-%3E%5Cr%5Cn%20%20%20%20if%20styleClassesArray%3F.length%5Cr%5Cn%20%20%20%20%20%20class%3A%20styleClassesArray.join%20%27%20%27%5Cr%5Cn%60%60%60%5Cr%5Cn%5Cr%5CnAnd%20just%20call%20%60%3Cfoo%20%7B%7Bclass%20myClasses%7D%7D%3E%60%20and%20it%20works%20great.%20%3A-%29%22%2C%20%22created_at%22%3A%20%222015-10-31T06%3A31%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/585279%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mitar%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20think%20they%20behave%20reactively%20like%20any%20other%20helper%2C%20no%3F%22%2C%20%22created_at%22%3A%20%222015-11-02T03%3A36%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-02T03%3A36%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes%2C%20we%20should%20maybe%20just%20explain%20a%20bit%20here%20more%2C%20and%20give%20some%20good-practice%20examples%20for%20those%20attribute-helpers.%22%2C%20%22created_at%22%3A%20%222015-11-02T03%3A39%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/585279%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mitar%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-03T01%3A33%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20outlines/blaze.md%3AL1-57%22%7D%2C%20%22Pull%20c5b034e4dad8ba662d32f972bf41ba4cf80cae53%20outlines/blaze.md%2016%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43568728%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20think%20we%20should%20still%20mention%20it%2C%20no%20matter%20what.%20People%20should%20know%20about%20them%20because%20they%20are%20often%20documented%20in%20old%20tutorials%20and%20Stack%20Overflow%20answers.%20Just%20ignoring%20that%20will%20make%20them%20hard%20to%20understand%20how%20to%20migrate%20to%20new%20stuff.%22%2C%20%22created_at%22%3A%20%222015-10-31T06%3A15%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/585279%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mitar%22%7D%7D%2C%20%7B%22body%22%3A%20%22Well%20this%20isn%27t%20the%20full%20documentation%20of%20spacebars%20%28or%20is%20it%3F%29.%20%5Cr%5Cn%5Cr%5CnI%20think%20in%20general%2C%20in%20the%20guide%20we%20mention%20things%20we%20think%20people%20should%20use.%20Like%20we%20aren%27t%20going%20to%20mention%20allow%20and%20deny%20really.%22%2C%20%22created_at%22%3A%20%222015-11-02T03%3A22%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40stubailo%20what%20do%20you%20think%20about%20this%3F%22%2C%20%22created_at%22%3A%20%222015-11-02T03%3A29%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3E%20I%20think%20in%20general%2C%20in%20the%20guide%20we%20mention%20things%20we%20think%20people%20should%20use.%5Cr%5Cn%5Cr%5CnYea%2C%20but%20I%20think%20that%20with%20proper%20use%20they%20are%20still%20useful.%20So%20maybe%20we%20should%20document%20proper%20use%2C%20instead%20of%20not%20documenting%20it%20at%20all.%20%3A-%29%22%2C%20%22created_at%22%3A%20%222015-11-02T03%3A32%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/585279%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mitar%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20think%20it%27s%20similar%20to%20allow/deny%20-%20we%20should%20mention%20it%20in%20the%20same%20way%20perhaps.%22%2C%20%22created_at%22%3A%20%222015-11-02T05%3A28%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-03T01%3A34%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20outlines/blaze.md%3AL1-59%22%7D%2C%20%22Pull%20d2231762773ac2dd73c8502c4004691d4c48def9%20outlines/blaze.md%2014%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/75%23discussion_r43528778%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22We%20_could_%20say%20that%20you%20don%27t%20want%20to%20use%20%60%7B%7B%23with%7D%7D%60%20or%20%60%7B%7B%23each%7D%7D%60%20in%20favor%20of%20%60%7B%7B%23let%7D%7D%60%20and%20%60%7B%7B%23each%20...%20in%20...%7D%7D%60.%22%2C%20%22created_at%22%3A%20%222015-10-30T17%3A24%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20think%20that%20until%20%60each%20...%20in%60%20provides%20a%20good%20way%20to%20access%20data%20in%20helpers%2C%20you%20will%20confuse%20people%3A%20https%3A//github.com/meteor/meteor/issues/5280%22%2C%20%22created_at%22%3A%20%222015-10-30T19%3A24%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/585279%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mitar%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27m%20not%20sure%20that%20accessing%20data%20context%20in%20helpers%20is%20actually%20a%20good%20idea%20at%20all.%20Are%20there%20any%20situations%20where%20it%20is%20actually%20a%20good%20idea%20in%20some%20way%20that%20isn%27t%20just%20saving%20keystrokes%3F%22%2C%20%22created_at%22%3A%20%222015-10-30T19%3A27%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20would%20agree%20here%20somewhat%2C%20because%20in%20Blaze%20Components%20data%20context%20is%20accessible%20only%20through%20explicit%20%60this.data%28%29%60.%20But%20yea%2C%20you%20do%20want%20to%20access.%20At%20least%20in%20my%20common%20use%20case%20for%20data%20contexts%20%28I%20use%20data%20context%20mostly%20only%20for%20this%2C%20other%20communication%20between%20components%20I%20do%20differently%29%2C%20which%20is%20instances%20of%20documents%20%28in%20my%20cases%20instances%20of%20PeerDB%20models%29.%20Then%20you%20have%20not%20just%20documents%2C%20but%20also%20methods%20on%20documents.%20So%20you%20can%20structure%20code%20in%20nice%20way%3A%20you%20have%20document%20properties%2C%20methods%20on%20the%20model%2C%20and%20component%20methods.%20So%20some%20code%20is%20more%20suitable%20to%20be%20together%20with%20a%20model%2C%20and%20some%20to%20be%20with%20view.%20But%20it%20is%20pretty%20normal%20then%20to%20call%20into%20model%20methods%20from%20template%20helpers%20as%20well.%5Cr%5Cn%5Cr%5CnIn%20some%20way%2C%20logic%20should%20be%20in%20template%20helpers%20in%20my%20opinion.%20Putting%20too%20much%20of%20it%20into%20templates%2C%20just%20so%20that%20you%20can%20then%20pass%20a%20value%20to%20a%20template%20helper%20so%20that%20it%20does%20not%20have%20to%20access%20the%20data%20context%20is%20probably%20bad.%5Cr%5Cn%5Cr%5CnSo%20what%20I%20am%20saying%20is%20that%20pure%20Blaze%20has%20some%20shortcomings%20but%20that%20is%20what%20we%20have.%20So%20we%20should%20be%20OK%20with%20that%20and%20explain%20how%20to%20use%20that%20effectively%2C%20even%20if%20it%20is%20not%20the%20best%20approach%20we%20would%20take%20now.%22%2C%20%22created_at%22%3A%20%222015-10-30T19%3A32%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/585279%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mitar%22%7D%7D%2C%20%7B%22body%22%3A%20%22For%20Blaze%20Components%20I%20decided%20I%20will%20just%20merge%20lexical%20scope%20with%20current%20data%20context.%20Users%20should%20have%20to%20think%20about%20this%20internal%20implementation%20details.%20If%20they%20can%20write%20%60%7B%7Bfoo%7D%7D%60%20inside%20%60each%20...%20in%60%20and%20it%20resolves%20to%20something%2C%20they%20should%20also%20be%20able%20to%20do%20%60this.data%28%29.foo%60.%20Otherwise%20this%20is%20really%20confusing.%5Cr%5Cn%5Cr%5CnMaybe%20a%20method%20on%20template%20instances%20like%20%60lookup%60%20could%20be%20helpful%2C%20which%20would%20do%20two%20things%3A%5Cr%5Cn%2A%20go%20in%20the%20same%20order%20as%20template%20lookup%20does%5Cr%5Cn%2A%20it%20would%20wrap%20reactivity%20only%20for%20that%20particular%20value%5Cr%5Cn%5Cr%5CnSo%20you%20could%20do%20%60Template.instance%28%29.lookup%28%27foo%27%29%60.%20So%20something%20I%20am%20contemplating%20here%3A%20https%3A//github.com/peerlibrary/meteor-blaze-components/issues/101%5Cr%5Cn%5Cr%5Cn%60resolve%60%20could%20also%20just%20be%20a%20global%20template%20helper%20we%20suggest%20to%20use%20%28same%20as%20%60instance%60%2C%20BTW%2C%20I%20have%20seen%20%60instance%60%20used%20more%20around%20in%20existing%20code%20I%20think%29.%22%2C%20%22created_at%22%3A%20%222015-10-30T19%3A38%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/585279%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mitar%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3E%20In%20some%20way%2C%20logic%20should%20be%20in%20template%20helpers%20in%20my%20opinion.%20Putting%20too%20much%20of%20it%20into%20templates%2C%20just%20so%20that%20you%20can%20then%20pass%20a%20value%20to%20a%20template%20helper%20so%20that%20it%20does%20not%20have%20to%20access%20the%20data%20context%20is%20probably%20bad.%5Cr%5Cn%5Cr%5CnI%20don%27t%20see%20what%20you%20mean%20here%20by%20%5C%22logic%5C%22%20-%20I%20wouldn%27t%20say%20managing%20which%20data%20is%20available%20where%20entails%20logic%2C%20since%20it%27s%20an%20inherent%20property%20of%20the%20view%20tree.%5Cr%5Cn%5Cr%5Cn%3E%20Maybe%20a%20method%20on%20template%20instances%20like%20lookup%20could%20be%20helpful%5Cr%5Cn%5Cr%5CnYes%2C%20I%20believe%20this%20is%20the%20best%20solution%20as%20well.%20I%27d%20love%20to%20have%20a%20sane%20version%20of%20%60Template.currentData%60%20with%20exactly%20the%20properties%20you%20describe.%20If%20we%20can%20agree%20on%20the%20design%2C%20I%27ll%20100%25%20accept%20a%20PR%20for%20that.%5Cr%5Cn%5Cr%5CnThere%20are%20some%20design%20questions%20though%2C%20and%20we%20should%20talk%20about%20them%20in%20a%20different%20thread%20of%20you%20would%20like%20to%20start%20one.%22%2C%20%22created_at%22%3A%20%222015-10-30T20%3A01%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22Oh%2C%20now%20I%20remembered%20why%20I%20was%20unable%20to%20implement%20this%20previously%3A%20https%3A//github.com/meteor/meteor/issues/4494%5Cr%5Cn%5Cr%5CnBecause%20my%20simple%20implementation%20would%20be%20something%20like%3A%5Cr%5Cn%5Cr%5Cn%60%60%60javascript%5Cr%5CnTemplate.registerHelper%28%27lookup%27%2C%20function%20%28name%29%20%7B%5Cr%5Cn%20%20var%20computedField%20%3D%20new%20ComputedField%28function%20%28%29%20%7B%5Cr%5Cn%20%20%20%20var%20value%20%3D%20Template.instance%28%29.view.lookup%28name%29%3B%5Cr%5Cn%20%20%20%20if%20%28_.isFunction%28value%29%29%20%7B%5Cr%5Cn%20%20%20%20%20%20value%20%3D%20value%28%29%3B%5Cr%5Cn%20%20%20%20%7D%5Cr%5Cn%20%20%20%20return%20value%3B%5Cr%5Cn%20%20%7D%5Cr%5Cn%20%20return%20computedField%28%29%3B%5Cr%5Cn%7D%29%3B%5Cr%5Cn%60%60%60%5Cr%5Cn%5Cr%5CnBut%2C%20autorun%20does%20not%20have%20access%20to%20template%20instance.%20%3A-%28%20In%20this%20particular%20case%20this%20could%20be%20solved%20with%3A%5Cr%5Cn%5Cr%5Cn%60%60%60javascript%5Cr%5CnTemplate.registerHelper%28%27lookup%27%2C%20function%20%28name%29%20%7B%5Cr%5Cn%20%20const%20view%20%3D%20Template.instance%28%29.view%3B%5Cr%5Cn%20%20var%20computedField%20%3D%20new%20ComputedField%28function%20%28%29%20%7B%5Cr%5Cn%20%20%20%20var%20value%20%3D%20view.lookup%28name%29%3B%5Cr%5Cn%20%20%20%20if%20%28_.isFunction%28value%29%29%20%7B%5Cr%5Cn%20%20%20%20%20%20value%20%3D%20value%28%29%3B%5Cr%5Cn%20%20%20%20%7D%5Cr%5Cn%20%20%20%20return%20value%3B%5Cr%5Cn%20%20%7D%5Cr%5Cn%20%20return%20computedField%28%29%3B%5Cr%5Cn%7D%29%3B%5Cr%5Cn%60%60%60%5Cr%5Cn%5Cr%5CnThe%20downside%20of%20this%20approach%20of%20course%20is%20that%20template%20helpers%20are%20always%20bound%20to%20data%20context%2C%20so%20this%20would%20rerun%20every%20time%20data%20context%20changes.%20Maybe%20to%20transition%20away%20from%20current%20Blaze%2C%20a%20new%20type%20of%20helpers%20could%20be%20defined%3F%20Like%20%5C%22methods%5C%22%3F%20Which%20would%20be%20the%20same%20as%20helpers%2C%20just%20that%20they%20have%20%60this%60%20set%20to%20the%20template%20instance%20and%20no%20automatic%20data%20context%20binding%3F%22%2C%20%22created_at%22%3A%20%222015-10-30T20%3A12%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/585279%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mitar%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yeah%2C%20I%20think%20that%20would%20be%20a%20clear%20improvement.%20%40tmeasday%20and%20I%20have%20been%20talking%20about%20this%2C%20and%20we%27ve%20been%20thinking%20about%20it%20internally%20for%20about%20a%20year%20now.%5Cr%5Cn%5Cr%5CnI%20think%20it%20could%20be%20as%20simple%20as%20a%20per-template%20feature%20flag%20that%20disables%20rerunning%20helpers%20on%20data%20context%20change%2C%20and%20the%20rest%20can%20be%20done%20in%20a%20package.%22%2C%20%22created_at%22%3A%20%222015-10-30T20%3A16%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20am%20not%20sure%20if%20template%20is%20the%20right%20granularity%20for%20this.%20Probably%20helper%20itself%3F%20What%20about%20a%20second%20argument%20to%20helpers%3F%5Cr%5Cn%5Cr%5Cn%60%60%60javascript%5Cr%5Cntemplate.helpers%28%7B%5Cr%5Cn%20%20%20...%5Cr%5Cn%7D%2C%20%7BdataContext%3A%20false%7D%29%3B%5Cr%5Cn%60%60%60%5Cr%5Cn%5Cr%5Cn%3F%22%2C%20%22created_at%22%3A%20%222015-10-30T20%3A22%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/585279%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mitar%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yea%2C%20that%20would%20be%20all%20it%20takes.%20The%20rest%20is%20then%20history.%20And%20a%20great%20migration%20path%20forward.%22%2C%20%22created_at%22%3A%20%222015-10-30T20%3A22%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/585279%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mitar%22%7D%7D%2C%20%7B%22body%22%3A%20%22And%20then%20we%20can%20add%20a%20function%20to%20template%20instance%20which%20gives%20you%20reactive%20access%20to%20data%20context%20%28or%20even%20lookup%2C%20as%20mentioned%20above%29.%22%2C%20%22created_at%22%3A%20%222015-10-30T20%3A23%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/585279%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mitar%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3E%20What%20about%20a%20second%20argument%20to%20helpers%3F%5Cr%5Cn%5Cr%5CnWhat%20about%20a%20replacement%20for%20helpers%3F%5Cr%5Cn%5Cr%5Cn%60%60%60%5Cr%5Cntemplate.boundHelpers%28%7B%5Cr%5Cn%20%20...%5Cr%5Cn%7D%29%3B%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-10-30T21%3A01%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes%2C%20that%27s%20what%20I%20thought%20with%3A%5Cr%5Cn%5Cr%5Cn%3E%20Maybe%20to%20transition%20away%20from%20current%20Blaze%2C%20a%20new%20type%20of%20helpers%20could%20be%20defined%3F%20Like%20%5C%22methods%5C%22%3F%20Which%20would%20be%20the%20same%20as%20helpers%2C%20just%20that%20they%20have%20this%20set%20to%20the%20template%20instance%20and%20no%20automatic%20data%20context%20binding%3F%5Cr%5Cn%5Cr%5CnBoth%20of%20those%20APIs%20could%20work.%20A%20new%20method%2C%20or%20options%20to%20an%20existing%20method.%22%2C%20%22created_at%22%3A%20%222015-10-30T21%3A03%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/585279%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mitar%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yep.%20Either%20one%20is%20fine%2C%20let%27s%20get%20it%20done%21%22%2C%20%22created_at%22%3A%20%222015-10-30T21%3A04%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22%28BTW%2C%20%60this%60%20should%20be%20bound%20to%20the%20template%20instance%20on%20which%20the%20helper%20is%20defined%2C%20not%20to%20a%20template%20instance%20where%20the%20template%20helper%20is%20invoked.%20For%20the%20latter%20%60Template.instance%28%29%60%20should%20be%20used.%29%22%2C%20%22created_at%22%3A%20%222015-10-30T21%3A05%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/585279%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mitar%22%7D%7D%2C%20%7B%22body%22%3A%20%22If%20there%20is%20more%20to%20follow%20up%2C%20let%27s%20do%20that%20in%20a%20different%20thread.%22%2C%20%22created_at%22%3A%20%222015-10-30T21%3A09%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20opened%20%235576%20and%20%235577.%20To%20be%20clear.%20I%20do%20not%20plan%20to%20work%20on%20PR%20for%20this.%22%2C%20%22created_at%22%3A%20%222015-10-30T21%3A23%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/585279%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mitar%22%7D%7D%2C%20%7B%22body%22%3A%20%22This%20is%20a%20great%20discussion%20guys%20and%20thanks%20for%20bringing%20all%20this%20stuff%20out%20into%20the%20open%20%40mitar.%20I%20think%20this%20conversation%20is%20really%2C%20really%20important%20as%20we%20discuss%20Blaze%20%28as%20I%20commented%20on%20the%20the%20other%20ticket%20just%20now%29.%5Cr%5Cn%5Cr%5CnFor%20now%2C%20I%27m%20updating%20this%20text%20to%20remove%20%60%7B%7B%23each%7D%7D%60%20and%20%60%7B%7B%23with%7D%7D%60%20and%20making%20a%20note%20about%20the%20resultant%20issues.%5Cr%5Cn%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-10-31T03%3A20%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-10-31T03%3A20%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20outlines/blaze.md%3AL1-57%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull d2231762773ac2dd73c8502c4004691d4c48def9 outlines/blaze.md 25'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/75#discussion_r43529025'>File: outlines/blaze.md:L1-57</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Do we know if this actually works with hot code push? I'm not sure that just adding the ID will cut it?
- <a href='https://github.com/mitar'><img border=0 src='https://avatars.githubusercontent.com/u/585279?v=3' height=16 width=16'></a> I think better then attaching reactive dict is to simply attach [reactive field](https://github.com/peerlibrary/meteor-reactive-field) or [computed field](https://github.com/peerlibrary/meteor-computed-field).
Then you can do things like:
```javascript
onCreated: function () {
this.foo = new ReactiveField(42);
}
```
And in the template:
```
{{instance.foo}}
```
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Curious why you chose the name "field" for those? Rather than property, value, etc?
- <a href='https://github.com/mitar'><img border=0 src='https://avatars.githubusercontent.com/u/585279?v=3' height=16 width=16'></a> Hm, no particular reason. :-) Field is something which is more used in MongoDB context, over property. Less characters to type. I didn't use value because the primary use case was with components for me.
But yea, it is not necessary the best naming. ;-)
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> So a reactive field is sugar around `ReactiveVar`? That's nice -- I can get behind it.
Yes, a reactive-dict works as advertised (exercise for the reader, update the scaffolded app to not use the `Session`, it's like a million times better and embarrassing that we haven't already done this).
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> So, I'd still recommend a dict as the "default" to start with (hint hint should just be a part of all templates without any work), as:
1. HCR-niceness
2. Can store more than one thing, which you usually want
3. You can still write `{{instance.state.get 'counter'}}`.
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> @stubailo agree?
- <a href='https://github.com/mitar'><img border=0 src='https://avatars.githubusercontent.com/u/585279?v=3' height=16 width=16'></a> Hm, I really think we should not make it be a part of template instance just so. We have too many places where people can store then stuff, into `state`, into template instance, into data context. Too many choices then mean people will be confused where to store it, and some people will use something, other something else so things will be less interoperable.
I really think that `{{instance.counter}}` is much nicer than `{{instance.state.get 'counter'}}`. Moreover, it allows you to have multiple stuff attached to `instance`. Like computer field, or simply a method/function. And you can then call all in the same way, with `instance.something`. Otherwise you have some stuff in `state`, some stuff in data context, some stuff as a method, some stuff as a computed field.
I really think this is bad design. There is no need for this. While my other comments are just  comments, here I really think strongly that the best thing is just to encourage use of template instances without any need for extra sub-namespacing into `state`.
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> The advantage of having a single point to store state is that it allows the system to do things for you.
Auto-migration on HCR is a big advantage that we see already here, but another is extra APIs like the equivalent of `shouldComponentUpdate(nextProps, nextState)`. This becomes a lot trickier if things are adhoc.
To your point on where people should store things, I think it's simple -- in the data if it's an argument (i.e. coming down the component heirarchy), in the state if it's state that's relevant to this component (and it's children, potentially).
Where it doesn't quite make sense is if you want to store something more complex than a serializable attribute -- for instance a computed field or a local collection. I don't have a good answer to this yet...
- <a href='https://github.com/mitar'><img border=0 src='https://avatars.githubusercontent.com/u/585279?v=3' height=16 width=16'></a> > Auto-migration on HCR is a big advantage that we see already here
But that could also be made automatically in the background? It is not so hard to go over all properties of a template instance and see which are reactive fields and have some interface to serialize and deserialize and stuff like that?
- [x] <a href='#crh-comment-Pull d2231762773ac2dd73c8502c4004691d4c48def9 outlines/blaze.md 3'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/75#discussion_r43474487'>File: outlines/blaze.md:L1-57</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Technically, the syntax is called spacebars, and the runtime is blaze. Like jsx and react.
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Speaking of Tracker, where do we cover that in the guide??
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> Hmm. No, we don't explicitly. I guess it is bigger than Blaze (you should know about how it works in the React world too). Does it deserve it's own (shorter) article?
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> https://github.com/meteor/guide/issues/77
- [x] <a href='#crh-comment-Pull d2231762773ac2dd73c8502c4004691d4c48def9 outlines/blaze.md 4'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/75#discussion_r43528704'>File: outlines/blaze.md:L1-57</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> I think in this guide, we should go into detail about data context and how it relates to "Views" - we gloss over this in the intro tutorial completely.
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> However, there is now a world in which you could use Blaze without data context entirely! We could see what that looks like.
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Ah, I see you have this in an explanation below.
- [x] <a href='#crh-comment-Pull d2231762773ac2dd73c8502c4004691d4c48def9 outlines/blaze.md 14'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/75#discussion_r43528778'>File: outlines/blaze.md:L1-57</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> We _could_ say that you don't want to use `{{#with}}` or `{{#each}}` in favor of `{{#let}}` and `{{#each ... in ...}}`.
- <a href='https://github.com/mitar'><img border=0 src='https://avatars.githubusercontent.com/u/585279?v=3' height=16 width=16'></a> I think that until `each ... in` provides a good way to access data in helpers, you will confuse people: https://github.com/meteor/meteor/issues/5280
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> I'm not sure that accessing data context in helpers is actually a good idea at all. Are there any situations where it is actually a good idea in some way that isn't just saving keystrokes?
- <a href='https://github.com/mitar'><img border=0 src='https://avatars.githubusercontent.com/u/585279?v=3' height=16 width=16'></a> I would agree here somewhat, because in Blaze Components data context is accessible only through explicit `this.data()`. But yea, you do want to access. At least in my common use case for data contexts (I use data context mostly only for this, other communication between components I do differently), which is instances of documents (in my cases instances of PeerDB models). Then you have not just documents, but also methods on documents. So you can structure code in nice way: you have document properties, methods on the model, and component methods. So some code is more suitable to be together with a model, and some to be with view. But it is pretty normal then to call into model methods from template helpers as well.
In some way, logic should be in template helpers in my opinion. Putting too much of it into templates, just so that you can then pass a value to a template helper so that it does not have to access the data context is probably bad.
So what I am saying is that pure Blaze has some shortcomings but that is what we have. So we should be OK with that and explain how to use that effectively, even if it is not the best approach we would take now.
- <a href='https://github.com/mitar'><img border=0 src='https://avatars.githubusercontent.com/u/585279?v=3' height=16 width=16'></a> For Blaze Components I decided I will just merge lexical scope with current data context. Users should have to think about this internal implementation details. If they can write `{{foo}}` inside `each ... in` and it resolves to something, they should also be able to do `this.data().foo`. Otherwise this is really confusing.
Maybe a method on template instances like `lookup` could be helpful, which would do two things:
* go in the same order as template lookup does
* it would wrap reactivity only for that particular value
So you could do `Template.instance().lookup('foo')`. So something I am contemplating here: https://github.com/peerlibrary/meteor-blaze-components/issues/101
`resolve` could also just be a global template helper we suggest to use (same as `instance`, BTW, I have seen `instance` used more around in existing code I think).
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> > In some way, logic should be in template helpers in my opinion. Putting too much of it into templates, just so that you can then pass a value to a template helper so that it does not have to access the data context is probably bad.
I don't see what you mean here by "logic" - I wouldn't say managing which data is available where entails logic, since it's an inherent property of the view tree.
> Maybe a method on template instances like lookup could be helpful
Yes, I believe this is the best solution as well. I'd love to have a sane version of `Template.currentData` with exactly the properties you describe. If we can agree on the design, I'll 100% accept a PR for that.
There are some design questions though, and we should talk about them in a different thread of you would like to start one.
- <a href='https://github.com/mitar'><img border=0 src='https://avatars.githubusercontent.com/u/585279?v=3' height=16 width=16'></a> Oh, now I remembered why I was unable to implement this previously: https://github.com/meteor/meteor/issues/4494
Because my simple implementation would be something like:
```javascript
Template.registerHelper('lookup', function (name) {
var computedField = new ComputedField(function () {
var value = Template.instance().view.lookup(name);
if (_.isFunction(value)) {
value = value();
}
return value;
}
return computedField();
});
```
But, autorun does not have access to template instance. :-( In this particular case this could be solved with:
```javascript
Template.registerHelper('lookup', function (name) {
const view = Template.instance().view;
var computedField = new ComputedField(function () {
var value = view.lookup(name);
if (_.isFunction(value)) {
value = value();
}
return value;
}
return computedField();
});
```
The downside of this approach of course is that template helpers are always bound to data context, so this would rerun every time data context changes. Maybe to transition away from current Blaze, a new type of helpers could be defined? Like "methods"? Which would be the same as helpers, just that they have `this` set to the template instance and no automatic data context binding?
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Yeah, I think that would be a clear improvement. @tmeasday and I have been talking about this, and we've been thinking about it internally for about a year now.
I think it could be as simple as a per-template feature flag that disables rerunning helpers on data context change, and the rest can be done in a package.
- <a href='https://github.com/mitar'><img border=0 src='https://avatars.githubusercontent.com/u/585279?v=3' height=16 width=16'></a> I am not sure if template is the right granularity for this. Probably helper itself? What about a second argument to helpers?
```javascript
template.helpers({
...
}, {dataContext: false});
```
?
- <a href='https://github.com/mitar'><img border=0 src='https://avatars.githubusercontent.com/u/585279?v=3' height=16 width=16'></a> Yea, that would be all it takes. The rest is then history. And a great migration path forward.
- <a href='https://github.com/mitar'><img border=0 src='https://avatars.githubusercontent.com/u/585279?v=3' height=16 width=16'></a> And then we can add a function to template instance which gives you reactive access to data context (or even lookup, as mentioned above).
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> > What about a second argument to helpers?
What about a replacement for helpers?
```
template.boundHelpers({
...
});
```
- <a href='https://github.com/mitar'><img border=0 src='https://avatars.githubusercontent.com/u/585279?v=3' height=16 width=16'></a> Yes, that's what I thought with:
> Maybe to transition away from current Blaze, a new type of helpers could be defined? Like "methods"? Which would be the same as helpers, just that they have this set to the template instance and no automatic data context binding?
Both of those APIs could work. A new method, or options to an existing method.
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Yep. Either one is fine, let's get it done!
- <a href='https://github.com/mitar'><img border=0 src='https://avatars.githubusercontent.com/u/585279?v=3' height=16 width=16'></a> (BTW, `this` should be bound to the template instance on which the helper is defined, not to a template instance where the template helper is invoked. For the latter `Template.instance()` should be used.)
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> If there is more to follow up, let's do that in a different thread.
- <a href='https://github.com/mitar'><img border=0 src='https://avatars.githubusercontent.com/u/585279?v=3' height=16 width=16'></a> I opened #5576 and #5577. To be clear. I do not plan to work on PR for this.
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> This is a great discussion guys and thanks for bringing all this stuff out into the open @mitar. I think this conversation is really, really important as we discuss Blaze (as I commented on the the other ticket just now).
For now, I'm updating this text to remove `{{#each}}` and `{{#with}}` and making a note about the resultant issues.
- [x] <a href='#crh-comment-Pull d2231762773ac2dd73c8502c4004691d4c48def9 outlines/blaze.md 35'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/75#discussion_r43529277'>File: outlines/blaze.md:L1-57</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Perhaps mention how cursors are better than arrays when working with Blaze
- <a href='https://github.com/mitar'><img border=0 src='https://avatars.githubusercontent.com/u/585279?v=3' height=16 width=16'></a> What are cursor-utils?
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> @mitar https://github.com/meteor/guide/issues/73
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> @stubailo yup
- [x] <a href='#crh-comment-Pull d2231762773ac2dd73c8502c4004691d4c48def9 outlines/blaze.md 21'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/75#discussion_r43542521'>File: outlines/blaze.md:L1-57</a></b>
- <a href='https://github.com/mitar'><img border=0 src='https://avatars.githubusercontent.com/u/585279?v=3' height=16 width=16'></a> Also, what about uses models and instances of models for data contexts? This works for us very well. Then you can just do `instanceof` checks if you really want.
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> I think SS allows you to do `instanceof` checks in a straightforward way, no?
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> :+1:
- <a href='https://github.com/mitar'><img border=0 src='https://avatars.githubusercontent.com/u/585279?v=3' height=16 width=16'></a> SS? And easy checking was not the point. The point is to suggest to people to maybe consider using high-level objects as data contexts. So to describe (it is a guide) a pattern where you use `transform` to transform your document from database, and then you use `instanceof` to find it.
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> Simple Schema.
We are going to describe that pattern (see collections article + helpers).
- <a href='https://github.com/mitar'><img border=0 src='https://avatars.githubusercontent.com/u/585279?v=3' height=16 width=16'></a> OK.
BTW, we should consider also something about JSON schema, a standard. Simple Schema is great, but it is not inter-operable with others. Not that we should do something about this now, but in the longer term it would be great if our publish functions/mongo collection would have JSON schema associated with it (then also EJSON would be simpler).
- [x] <a href='#crh-comment-Pull d2231762773ac2dd73c8502c4004691d4c48def9 outlines/blaze.md 24'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/75#discussion_r43542682'>File: outlines/blaze.md:L1-57</a></b>
- <a href='https://github.com/mitar'><img border=0 src='https://avatars.githubusercontent.com/u/585279?v=3' height=16 width=16'></a> Or `instance`?
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Yeah, I think we should add some official naming here - for example "template class" and "template instance"?
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> That would be the obvious one. I'll switch this to `{{instance}}` as it's clearer and I think what most people are doing anyway.
- [x] <a href='#crh-comment-Pull d2231762773ac2dd73c8502c4004691d4c48def9 outlines/blaze.md 26'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/75#discussion_r43544956'>File: outlines/blaze.md:L1-57</a></b>
- <a href='https://github.com/mitar'><img border=0 src='https://avatars.githubusercontent.com/u/585279?v=3' height=16 width=16'></a> Using reactive field you get that for free. :-)
```
template.onCreated(function () {
this.foo = new ReactiveField(42);
});
template.events({
'click button': function (event, instance) {
instance.foo($(event.currentTarget).val());
}
});
```
```
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> Oh right, but I mean complicated state changes that shouldn't be in the event handler. Like
```js
Template.X.onCreated(function() {
this.updateFoo = (input) => {
const newValue = do * something + complicated / with * foo;
this.state.set('foo', newValue);
}
});
Template.X.events({
'click button': function(event, instance) {
instance.updateFoo(event.target.value);
}
});
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> :+1:
- <a href='https://github.com/mitar'><img border=0 src='https://avatars.githubusercontent.com/u/585279?v=3' height=16 width=16'></a> Exactly. That is what we even suggest in Blaze Components. That event maps should map between selectors and methods and then all event handling should be in methods. Then you can extend those methods in child classes. And then it is really cool when:
```
this.updateFoo = (input) => {
const newValue = do * something + complicated / with * this.foo();
this.foo(newValue);
}
```
So that you can access reactive fields as you would access some other method or property on template instance. This is a really powerful pattern.
- [x] <a href='#crh-comment-Pull d2231762773ac2dd73c8502c4004691d4c48def9 outlines/blaze.md 31'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/75#discussion_r43545240'>File: outlines/blaze.md:L1-57</a></b>
- <a href='https://github.com/mitar'><img border=0 src='https://avatars.githubusercontent.com/u/585279?v=3' height=16 width=16'></a> Maybe document wait for subscription to finish pattern I have to use regularly:
```
onRendered(function ()
const instance = Template.instance();
this.autorun(function (computation) {
if (!instance.subscriptionsReady()) return;
computation.stop();
// Use 3rd party stuff to render now something.
});
});
```
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Yeah, this is an unfortunate pattern, we should add it here. lol
- <a href='https://github.com/mitar'><img border=0 src='https://avatars.githubusercontent.com/u/585279?v=3' height=16 width=16'></a> Talking about promises, this is one very common pattern I am using and I have not yet made a package for it. This wait for condition and stop autoruns.
- <a href='https://github.com/mitar'><img border=0 src='https://avatars.githubusercontent.com/u/585279?v=3' height=16 width=16'></a> I am using it a lot for inter-component communication: https://github.com/peerlibrary/meteor-blaze-components/issues/82 But I have not yet found a good name or API for it.
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> Good one, thanks @mitar
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> :+1:
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> (PS this is exactly the sort of kludge that I think should make it into the guide .. ;) )
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> :+
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> :+1:
- <a href='https://github.com/mitar'><img border=0 src='https://avatars.githubusercontent.com/u/585279?v=3' height=16 width=16'></a> If you help me find a good API for this, I can maybe make a package which wraps it up. Like `AutorunPromise`? :-) Or `Tracker.wait`? Like `Tracker.wait(condition, body)`?
- <a href='https://github.com/mitar'><img border=0 src='https://avatars.githubusercontent.com/u/585279?v=3' height=16 width=16'></a> Note to myself, improved:
```
onRendered(function ()
const instance = this;
this.autorun(function (computation) {
if (!instance.subscriptionsReady()) return;
computation.stop();
Tracker.nonreactive(function () {
// Use 3rd party stuff to render now something.
});
});
});
```
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> Lol. Circa 2012: https://github.com/tmeasday/meteor-deps-extensions#await
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> :+1:
- <a href='https://github.com/mitar'><img border=0 src='https://avatars.githubusercontent.com/u/585279?v=3' height=16 width=16'></a> So, should I make a package only for this or what? :-)
BTW, I am starting to think that this could also be combined with promises. I will wrote more into the ticket about promises.
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> Well I think a `tracker-extensions` package is probably a pretty handy thing if stuff can be built without needing changes to core. Please take anything from my old deps-extension package that is still relevant if you do end up making the package, and let me know if you make the package.
- [x] <a href='#crh-comment-Pull d2231762773ac2dd73c8502c4004691d4c48def9 outlines/blaze.md 44'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/75#discussion_r43545430'>File: outlines/blaze.md:L1-57</a></b>
- <a href='https://github.com/mitar'><img border=0 src='https://avatars.githubusercontent.com/u/585279?v=3' height=16 width=16'></a> And attributes how are they changed?
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> @mitar I'm not quite sure what you mean here?
- <a href='https://github.com/mitar'><img border=0 src='https://avatars.githubusercontent.com/u/585279?v=3' height=16 width=16'></a> So DOM element attributes. Things like `<div {{attrs}}>`. So we should explain how do they reactivelly change as well, no?
BTW, with Blaze Components there is also a nice pattern which emerged for attributes. Namely that you can have multiple sources contribute to the same dict which you then render out. Like a dict of CSS classes, and inline style, and then you render them at once out. Instead of patching them together in templates. With inheritance and mixins you can do this really well.
- <a href='https://github.com/mitar'><img border=0 src='https://avatars.githubusercontent.com/u/585279?v=3' height=16 width=16'></a> Then you can have a simple helper like:
```
# Converts an array of style classes into a class attribute. It doesn't return anything
# if the array is empty (or null) so that class attribute is not unnecessarily created.
class: (styleClassesArray) ->
if styleClassesArray?.length
class: styleClassesArray.join ' '
```
And just call `<foo {{class myClasses}}>` and it works great. :-)
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> I think they behave reactively like any other helper, no?
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> :+1:
- <a href='https://github.com/mitar'><img border=0 src='https://avatars.githubusercontent.com/u/585279?v=3' height=16 width=16'></a> Yes, we should maybe just explain a bit here more, and give some good-practice examples for those attribute-helpers.
- [x] <a href='#crh-comment-Pull c5b034e4dad8ba662d32f972bf41ba4cf80cae53 outlines/blaze.md 16'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/75#discussion_r43568728'>File: outlines/blaze.md:L1-59</a></b>
- <a href='https://github.com/mitar'><img border=0 src='https://avatars.githubusercontent.com/u/585279?v=3' height=16 width=16'></a> I think we should still mention it, no matter what. People should know about them because they are often documented in old tutorials and Stack Overflow answers. Just ignoring that will make them hard to understand how to migrate to new stuff.
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> Well this isn't the full documentation of spacebars (or is it?).
I think in general, in the guide we mention things we think people should use. Like we aren't going to mention allow and deny really.
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> @stubailo what do you think about this?
- <a href='https://github.com/mitar'><img border=0 src='https://avatars.githubusercontent.com/u/585279?v=3' height=16 width=16'></a> > I think in general, in the guide we mention things we think people should use.
Yea, but I think that with proper use they are still useful. So maybe we should document proper use, instead of not documenting it at all. :-)
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> I think it's similar to allow/deny - we should mention it in the same way perhaps.
- [x] <a href='#crh-comment-Pull c5b034e4dad8ba662d32f972bf41ba4cf80cae53 outlines/blaze.md 27'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/75#discussion_r43568745'>File: outlines/blaze.md:L1-59</a></b>
- <a href='https://github.com/mitar'><img border=0 src='https://avatars.githubusercontent.com/u/585279?v=3' height=16 width=16'></a> Let's do `instance = Template.instance()` here as well.
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> Yeah, I'm inclined to agree. My only hesitancy would be that in all documentation ever you find on the web you'll see `function(event, template)` in event handlers. We are now saying you should write `function(event, instance)` I guess.
@stubailo what do you think?
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> I think it's not a big deal. I'd obviously prefer `this`, but `instance` or `self` would be second best. The word `template` is over-used, who knows what it refers to.
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> I think we just need to be consistent across template access, event handlers and helpers. I think `instance` works best for those three so we'll run with it.


<a href='https://www.codereviewhub.com/meteor/guide/pull/75?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/meteor/guide/pull/75?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/meteor/guide/pull/75'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>