### PR TITLE
Data loading content

### DIFF
--- a/content/data-loading.md
+++ b/content/data-loading.md
@@ -123,8 +123,6 @@ Subscribing to data puts it in your client-side collections. To use the data in 
 
   Note that there are some exceptions to this second rule. A common one is `Meteor.user()`---although this is strictly speaking subscribed to (automatically usually), it's typically over-complicated to pass it through the template heirarchy as an argument to each template. Although you could do this if you want to be "pure" about everything, and it's best not to use it in too many places as it makes templates harder to test.
 
-  A second exception is sometimes in Blaze when you want to be more performant by controlling re-renderings. As an example in the Todos example application, although we subscribe to the `lists/todos` publication in the `listShowPage`, we don't actually fetch the todos further down the template heirarchy, in order to avoid the todos rendering too much when properties of the list change.
-
 ### Global subscriptions
 
 One place where you might be tempted to not subscribe inside a template is when it accesses data that you know you *always* need. For instance, a subscription to extra fields on the user object (see the {% post_link accounts "Accounts Article" %}) that you need on every screen of your app.
@@ -200,9 +198,7 @@ A very common pattern of data access is pagination. This refers to the practice 
 
 There are two styles of pagination that are commonly used, a "page-by-page" style---where you show only one page of results at a time, starting at some offset (which the user can control), and "infinite-scroll" style, where you show and increasing number of pages of items, as the user moves through the list (this is the typical "feed" style user interface).
 
-Let's consider a publication/subscription technique for the second (the first technique is quite difficult to do correctly in Meteor as you can't tell at which offset to start on the client-side which only has a subset of the true data).
-
-XXX: Should we deal with the page-to-page pagination scenario better?
+Let's consider a publication/subscription technique for the second (the first technique is a little tricker to handle, due to it being difficult to calculate the offset on the client. If you need to do so, you can follow many of the same techniques that we use here and use the [`percolate:find-from-publication`](https://atmospherejs.com/percolate/find-from-publication) package to keep track of which records have come from your publication).
 
 In an infinite scroll publication, we simply need to add a new argument to our publication controlling how many items to load. Suppose we wanted to paginate the todo items in our Todos example app:
 
@@ -294,7 +290,7 @@ If you need to query the store, or store many related items, it's probably a goo
 
 ### Accessing stores
 
-You should access stores in the same way you'd access other reactive data in your templates. For a Blaze template, that's either in a helper, or from within a `this.autorun()` inside an `onCreated()` callback. 
+You should access stores in the same way you'd access other reactive data in your templates---that means centralizing your store access, much like you centralize your subscribing and data fetch. For a Blaze template, that's either in a helper, or from within a `this.autorun()` inside an `onCreated()` callback. 
 
 This way you get the full reactive power of the store.
 
@@ -457,8 +453,6 @@ One point to be aware of is that if you allow the user to *modify* data in the "
 As a concrete example of using the low-level API, consider the situation where you have some 3rd party REST endpoint which provides a changing set of data that's valuable to your users. How do you make that data available to your users?
 
 One option would be to provide a Method that simply proxies through to the endpoint, for which it's the client's responsibility to poll and deal with the changing data as it comes in. So then it's the clients problem to deal with keeping a local data cache of the data, updating the UI when changes happen, etc etc. Although this is possible (you could use a Local Collection to store the polled data in, for instance), it's simpler, and more natural to create a publication that does this polling for the client.
-
-XXX: is there anything on atmosphere that does this?
 
 A pattern for turning a polled REST endpoint looks something like this:
 

--- a/content/data-loading.md
+++ b/content/data-loading.md
@@ -1,0 +1,57 @@
+---
+title: Data Loading and Management
+---
+
+
+
+1. Publications + Subscriptions
+  1. What are they? - compare REST endpoint
+  2. How do they work? - talk about bridging data from server-client collections
+  3. What's a pub / what's a sub
+2. Defining a publication on the server
+  1. Rules around what arguments it should take
+  2. Where should it go? (which package -- depends on universality)
+3. Subscribing on the client
+  1. Subscriptions should be initiated by templates/components that need the data
+  2. Retrieve the data from the sub at the same point as subscribing, pass down and filter via `cursor-utils`
+  3. Global required data should be subscribed by an always there "layout" template
+4. Data loading patterns
+  4. Monitoring subscription readiness + errors
+    1. Using `Template.subscriptionsReady`
+    2. Passing subscription readiness into sub-components alongside data (see UI/UX chapter)
+  5. Subscriptions + changing inputs, how autoruns can help.
+    1. Basic techniques using `this.autorun`/other reactive contexts and `Template.currentData()`/other reactive sources
+    2. How it works
+      1. The subscription realizes it's called from within a reactive context
+      2. When invalidated, subscription marks itself invalid
+      3. When re-running, if re-run with the same arguments, the sub is a no-op
+      4. Otherwise the new sub starts, *goes ready*, then the old sub is stopped.
+  6. Paginating subscription data -- combining the above
+    1. A basic paginated publication
+    2. A publication that returns a count
+    3. Passing pagination info into a template/component
+      1. `totalCount`, `requested`, `currentItems`
+    4. Passing a `loadMore` callback into a template/component, using it to increment `requested`.
+5. Other data -- global client only data # NOTE LIVES SOMEWHERE ELSE I GUESS?
+  1. Concept of a "store"
+  2. Types of store:
+    1. If it's a single dimension, use a reactive var
+    2. If it's a few dimensions (or you need HCR), use a named reactive dict
+    3. If you need to query it, use a local collection.
+  3. How to listen to a store (autorun / helper / getMeteorData / angular version?)
+  4. How to update a store:
+    1. Built in APIs
+    2. Adding APIs to stores via `XStore.foo = () => {}` (they are singletons, so no need to make class)
+6. Publishing relational data
+  1. Common misconceptions about publication reactivity + naive implementation
+    1. There's no reactivity in a publish function apart from:
+      1. `userId`
+      2. The way that `publishCursor` works.
+  2. Using publish-composite to get it done the way you'd expect.
+7. Complex authorization in publications
+  1. Is kind of impossible to do correctly - https://github.com/meteor/meteor/issues/5529 (unelss we recommend a fully reactive publish solution, which we don't)
+8. The low-level publish API
+  1. Custom publication patterns - how to decouple your backend data format from your frontend (if you want!)
+  2. Be super careful about leaking!! (How to detect this, perf article)
+9. Turning pubs into REST endpoints (via `simple:rest`)
+10. Turning REST endpoints into pubs via `poll-publish`

--- a/content/data-loading.md
+++ b/content/data-loading.md
@@ -112,6 +112,8 @@ Once you've subscribed to a set of data, you then need to query the client colle
 
   If you don't do this, then you open yourself up to problem if another subscription pushes data into the same collection. Although you may be confident that this is not the case, in an actively developed application, it's impossible to anticipate what may change in the future and this can be a source of hard to understand bugs.
 
+  Also, when changing subscriptions, there is a brief period where both subscriptions are loaded (see "Publication behaviour when changing arguments" below), so when doing thing like pagination, it's exceedingly likely that this will be the case.
+
 2. Fetch the data as close as possible to where you subscribe to it.
 
   We do this for the same reason we subscribe in the template in the first place -- to avoid action at a distance and to make it easier to understand where data comes from. A common pattern is to fetch the data in a parent template, and then pass it into a "pure" child template, as we'll see in in the {% post_link ui-ux "UI/UX Article"%}.
@@ -126,6 +128,186 @@ One place where you might be tempted to not subscribe to a subscription is when 
 
 However, it's generally a good idea to use a layout template (which you wrap all your templates in) to subscribe to this subscription anyway. It's better to be consistent about such things, and it makes for a more flexible system if you ever decide you have a screen that *doesn't* need that data.
 
+
+## Patterns for data loading
+
+Across Meteor applications, there are some common patterns of data loading and and management on the client side that are worth knowing. We'll go into more detail about some of these in the {% post_link ui-ux "UI/UX Article" %}.
+
+### Subscription readiness
+
+A key thing to keep in mind is that a subscription will not instantly provide it's data. There'll be a latency between subscribing to the data on the client and it arriving from the publication on the server (and keep in that this time may be a lot longer for your users in production that for you locally in development!)
+
+Although the Tracker system means you often don't *need* to think too much about this in building your apps, usually if you want to get the user experience right, you'll need to know when the data is ready. 
+
+To find that out, `Meteor.subscribe()` and (`this.subscribe()` in templates) returns a "subscription handle", which contains a reactive data source called `.ready()`:
+
+```js
+const handle = Meteor.subscribe('lists/public');
+Tracker.autorun(() => {
+  console.log(`Handle is ${handle.ready() ? 'ready' : 'not ready'}`);  
+});
+```
+
+We can use this information to be more subtle about when we try and show data to users, and when we show a loading screen.
+
+### Changing subscription arguments
+
+We've seen an example already of using an `autorun` to re-subscribe when the (reactive) arguments to a subscription change. It's worth digging in a little more detail to understand what happens in this scenario.
+
+```js
+Template.listsShowPage.onCreated(function() {
+  this.state = new ReactiveDict();
+  this.autorun(() => {
+    this.state.set('listId', FlowRouter.getParam('_id'));
+    this.subscribe('list/todos', this.state.get('listId'));
+  });
+});
+```
+
+In our example, the `autorun` will re-run whenever `this.state.get('listId')` changes, (ultimately because `FlowRouter.getParam('_id')` changes), although other common reactive data sources are:
+
+1. Template data contexts (which you can access reactively with `Template.currentData()`)
+2. The current user status (`Meteor.user()` and `Meteor.loggingIn()`)
+3. The contents of other application specific client data stores.
+
+Technically, what happens when one of these reactive sources changes is the following:
+
+1. The reactive data source *invalidates* the autorun computation (tells it to re-run itself)
+2. The subscription detects this, and given that anything is possible in next computation run, marks itself for destruction.
+3. The computation re-runs, with `.subscribe()` being re-called either with new or different arguments.
+4a. If the subscription is run with the *same arguments* then the "new" subscription discovers the old "marked for destruction" subscription that sitting around, with the same data already ready, and simply reuses that.
+4b. If the subscription is run with *different arguments*, then a new subscription is created, which connects to the publication on the server
+5. At the end of the flush cycle (i.e. after the computation is done re-running), the old subscription checks to see if it was re-used, and if not, sends a message to the server to tell the server to shut it down.
+
+The important detail in the above is in 4a --- that they system cleverly knows not to re-subscribe if the autorun re-runs and subscribes with the exact same arguments. This holds true even if the new subscription is set up somewhere else in the template heirarchy.
+
+For instance if a user navigates between two pages that both subscribe to the exact same subscription, the same mechanism will kick in and no unnecessarily subscribing will happen.
+
+### Publication behaviour when changing arguments
+
+It's also worth knowing a little about what happens on the server when the new subscription is started and the old one is stopped.
+
+The server *explicitly* waits until all the data is sent down (the new subscription is ready) for the new subscription before removing the data from the old subscription. The idea here is to avoid flicker -- you can, if desired, continue to show the old subscription's data until the new data is ready, then instantly switch over to the new subscription's complete data set.
+
+What this means is in general, when changing subscriptions, there'll be a period where you are *over-subscribed* and there is more data on the client than you strictly asked for. This is one very important reason why you should always fetch the same data that you have subscribed to (don't "over-fetch").
+
+### Paginating subscriptions
+
+A very common pattern of data access is pagination. This refers to the practice of fetching a ordered list of data one "page" at a time --- typically some number of items, say twenty.
+
+There are two styles of pagination that are commonly used, a "page-by-page" style---where you show only one page of results at a time, starting at some offset (which the user can control), and "infinite-scroll" style, where you show and increasing number of pages of items, as the user moves through the list (this is the typical "feed" style user interface).
+
+Let's consider a publication/subscription technique for the second (the first technique is quite difficult to do correctly in Meteor as you can't tell at which offset to start on the client-side which only has a subset of the true data).
+
+XXX: Should we deal with the page-to-page pagination scenario better?
+
+In an infinite scroll publication, we simply need to add a new argument to our publication controlling how many items to load. Suppose we wanted to paginate the todo items in our Todos example app:
+
+```js
+const MAX_TODOS = 1000;
+
+Meteor.publish('list/todos', function(listId, limit) {
+  check(listId, String);
+  check(limit, Number);
+
+  const options = {
+    sort: {createdAt: -1},
+    limit: Math.min(limit, MAX_TODOS)
+  };
+
+  ...
+});
+```
+
+It's important that we set a `sort` parameter on our query (after, which first `limit` todos do we want?), and that we set an absolute maximum on the number of items a user can request (at least in the case where lists can grow without bound).
+
+Then on the client side, we'd some kind of reactive state variable to control how many items to request:
+
+```js
+Template.listsShowPage.onCreated(function() {
+  this.state = new ReactiveDict();
+  this.autorun(() => {
+    this.state.set('listId', FlowRouter.getParam('_id'));
+    this.subscribe('list/todos', this.state.get('listId'), this.state.get('requestedTodos'));
+  });
+});
+```
+
+We'd increment that `requestedTodos` variable when the user clicks "load more" (or perhaps just when they scroll to the bottom of the page).
+
+Once piece of information that's very useful to know when paginating data is the *total number of items* that you could see. The `[tmeasday:publish-counts](https://atmospherejs.com/tmeasday/publish-counts)` can be useful to publish this. We could add a `/list/todoCount` publication like so
+
+```js
+Meteor.publish('list/todoCount', function(listId) {
+  check(listId, String);
+  
+  Counts.publish(this, `list/todoCount${listId}`, Todos.find({listId}));
+});
+```
+
+Then on the client, after subscribing to that publication, we can access the count with `Counts.get(``list/todoCount${listId}`)`.
+
+## Other (non-published) data sets: Stores
+
+In Meteor, persistent or shared data comes over the wire on publications. However, there are some types of data which doesn't need to be persistent or shared between users. For instance, the "logged-in-ness" of the current user, or the route they are currently viewing. 
+
+Although client-side state is often best contained as state of an individual template (and passed down the template heirarchy as arguments where necessary), sometimes you have a need for "global" state that is shared between unrelated sections of the template heirarchy.
+
+Usually such state is stored in a *global singleton* object which we can call a store. A singleton is a data structure of which only a single copy logically exists. The current user and the router from above are typical examples of such global singletons. 
+
+### Types of stores
+
+In Meteor, it's best to make stores *reactive data* sources, as that way they tie most naturally into the rest of the ecosystem. There are a few different packages you can use for stores.
+
+If the store is single-dimensional, you can probably use a `ReactiveVar` to store it (provided by the `reactive-var` package). A `ReactiveVar` has two properties, `get()` and `set()`:
+
+```js
+DocumentHidden = new ReactiveVar(document.hidden);
+$(window).on('visibilitychange', (event) => {
+  DocumentHidden.set(document.hidden);
+});
+```
+
+If the store is multi-dimensional, you may want to use a `ReactiveDict` (from the `reactive-dict` package):
+
+```js
+const $window = $(window);
+const getDimensions = () => {
+  return {
+    width: $window.width(),
+    height: $window.height()
+  };
+};
+
+WindowSize = new ReactiveDict(getDimensions());
+$window.on('resize', () => {
+  WindowSize.set(getDimensions());
+});
+```
+
+The advantage of a `ReactiveDict` is you can access each property individually (`WindowSize.get('width')`), and isolate the reactivity.
+
+If you need to query the store, or store many related items, it's probably a good idea to use a Local Collection (see the {% page_link collections "Collections Article" %}.
+
+### Accessing stores
+
+You should access stores in the same way you'd access other reactive data in your templates. For a Blaze template, that's either in a helper, or from within a `this.autorun()` inside an `onCreated()` callback. For React, it's from your `getMeteorData()` function. 
+
+This way you get the full reactive power of the store.
+
+### Updating stores
+
+If you need to update a store from as a result of user action, you'd update the store from an event handler, just like you call Methods. 
+
+If you need to perform complex logic in the update (i.e. not just call `.set()` etc), it's a good idea to define a mutator on the store. As the store is a singleton, you can just attach a function to the object directly:
+
+```js
+WindowSize.simulateMobile = (device) => {
+  if (device === 'iphone6s') {
+    this.set({width: 750, height: 1334});
+  }
+}
+```
 
 # OUTLINE
 

--- a/content/data-loading.md
+++ b/content/data-loading.md
@@ -353,8 +353,8 @@ Meteor.publishComposite('list/todos', function(listId) {
   return {
     find() {
       const query = {
-        _id: listId, 
-        userId: {$or: [{$exists: false}, userId]}
+        _id: listId,
+        $or: [{userId: {$exists: false}}, {userId}]
       };
 
       return Lists.find(query);

--- a/content/data-loading.md
+++ b/content/data-loading.md
@@ -345,8 +345,6 @@ However, we can write publications that are properly reactive to changes across 
 
 The way this package works is to first establish a cursor on one collection, and then explicitly set up a second level of cursors on a second collection with the results of the first cursor.
 
-XXX: this example isn't actually in the app yet: https://github.com/meteor/todos/issues/48
-
 ```js
 Meteor.publishComposite('list/todos', function(listId) {
   check(listId, String);
@@ -452,10 +450,6 @@ Data published like this, from the client's perspective doesn't look any differe
 
 One point to be aware of is that if you allow the user to *modify* data in the "psuedo-collection" you are publishing in this fashion, you'll want to be sure to re-publish the modifications to them via the publication. 
 
-
-XXX: should we talk about sharing observers?
-
-XXX: should we talk about techniques to share data/work between common custom publications?
 
 ## Turning a REST endpoint into a publication
 

--- a/content/data-loading.md
+++ b/content/data-loading.md
@@ -52,12 +52,13 @@ Meteor.publish('lists/private', function() {
 
 What this means is that the above publication can be confident (thanks to Meteor's accounts system) that it will only ever publish private lists to the user that they belong to. Note also that the publication will re-run if the user logs out (or back in again), which means that the published set of private lists will reflect this.
 
-In the case of a non-logged in user, we explicitly call `this.ready()`, which indicates to the subscription that we've sent all the data we are initially going to send (in this case none).
+In the case of a non-logged in user, we explicitly call `this.ready()`, which indicates to the subscription that we've sent all the data we are initially going to send (in this case none). It's important to know that if you don't return a cursor from the publication or call `this.ready()`, the user's subscription will never become ready, and they will likely see a loading state forever.
 
 The other type of publication argument is a simple named argument:
 
 ```js
 Meteor.publish('list/todos', function(listId) {
+  // We always need to check the `listId` is the type we expect
   check(listId, String);
 
   ...
@@ -70,8 +71,6 @@ When we create a subscription to this piblication on the client, we can provide 
 Meteor.subscribe('list/todos', list._id);
 ```
 
-Also note that we are careful to check the `listId` is a string as we expect, as described in the Security article.
-
 ### Organizing Publications
 
 It makes sense to place a publication in a package alongside the feature that it's targeted. For instance, sometimes publications provide very specific data that's only really useful for the view that they are developed for. In that case, placing the publication in the same package as the view code makes perfect sense.
@@ -81,6 +80,9 @@ Often, however, a publication is more general. For example in the Todos example 
 ## Using publications: Subscriptions
 
 To use publications, you need to create a subscription to it on the client. To do so, you call `Meteor.subscribe()` with the name of the publication. When you do this, it opens up a subscription to that publication, and the server starts sending data down the wire to ensure that your client collections contain up to date copies of the data that's pushed by the publication.
+
+Also, `Meteor.subscribe()` returns a "subscription handle", with a property called `.ready()` defined -- a reactive function that returns `true` when the publication becomes ready (either you call `this.ready()` explicitly, or the current contents of a returned cursor are sent over).
+
 
 ### Organizing Subscriptions
 

--- a/content/data-loading.md
+++ b/content/data-loading.md
@@ -86,7 +86,7 @@ Also, `Meteor.subscribe()` returns a "subscription handle", with a property call
 
 ### Organizing Subscriptions
 
-It is best to place the subscription as close as possible to the place where the data from the subscription is needed. This reduces "action at a distance" and makes it easier to understand the flow of data through your application.
+It is best to place the subscription as close as possible to the place where the data from the subscription is needed. This reduces "action at a distance" and makes it easier to understand the flow of data through your application. If the subscription and fetch are separated, then it's not always clear how and why changes to the subscriptions (such as changing arguments), will affect the contents of the cursor.
 
 What this means in practice is that you should place your subscription calls in *templates*. In Blaze, it's best to do this in the `onCreated()` callback:
 
@@ -102,7 +102,7 @@ Template.listsShowPage.onCreated(function() {
 
 In this code snippet we can see two important techniques for subscribing in Blaze templates:
 
-1. Calling `this.subscribe()` (rather than `Meteor.subscribe`) means that the subscription will automatically get torn down when the template is taken off the screen.
+1. Calling `this.subscribe()` (rather than `Meteor.subscribe`), which attaches a special `this.subscriptionsReady()` function to the template instance, which is true when this and other subscriptions are ready.
 
 2. Calling `this.autorun` sets up a reactive context which will re-initialize the subscription whenever the reactive variable `this.state.get('listId')` changes.
 

--- a/content/data-loading.md
+++ b/content/data-loading.md
@@ -94,8 +94,9 @@ What this means in practice is that you should place your subscription calls in 
 Template.listsShowPage.onCreated(function() {
   this.state = new ReactiveDict();
   this.autorun(() => {
-    this.state.set('listId', FlowRouter.getParam('_id'));
-    this.subscribe('list/todos', this.state.get('listId'));
+    const listId = FlowRouter.getParam('_id');
+    this.state.set({listId});
+    this.subscribe('list/todos', listId);
   });
 });
 ```

--- a/content/data-loading.md
+++ b/content/data-loading.md
@@ -2,7 +2,22 @@
 title: Data Loading and Management
 ---
 
+After reading this guide, you'll know:
 
+1. What publications and subscriptions are in the Meteor framework
+2. How to define a publication on the server
+3. Where to subscribe on the client and in which template
+4. Useful patterns to follow to subscribe sensibly and help users understand the state of subscriptions.
+5. How to create publish sets of related data in a reactive way.
+6. How to ensure your publication is properly authorized in a reactive way.
+7. How to use the low-level publish API to publish anything.
+8. How to turn a 3rd-party REST endpoint into a publication.
+9. How to turn a publication into your app into a REST endpoint.
+
+
+
+
+# OUTLINE
 
 1. Publications + Subscriptions
   1. What are they? - compare REST endpoint

--- a/content/data-loading.md
+++ b/content/data-loading.md
@@ -294,7 +294,7 @@ If you need to query the store, or store many related items, it's probably a goo
 
 ### Accessing stores
 
-You should access stores in the same way you'd access other reactive data in your templates. For a Blaze template, that's either in a helper, or from within a `this.autorun()` inside an `onCreated()` callback. For React, it's from your `getMeteorData()` function. 
+You should access stores in the same way you'd access other reactive data in your templates. For a Blaze template, that's either in a helper, or from within a `this.autorun()` inside an `onCreated()` callback. 
 
 This way you get the full reactive power of the store.
 


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/meteor/guide/pull/97%23issuecomment-158869667%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23issuecomment-161157425%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23issuecomment-161888029%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23issuecomment-161906589%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23issuecomment-161906662%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45576527%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45576543%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45576576%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45576626%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45576641%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45576682%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45576714%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45576733%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45576734%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45576786%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45576821%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45576849%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45576909%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45576941%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45576966%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45576986%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45577098%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45577174%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45577184%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45577185%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45577213%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45577214%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45577226%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45577234%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45577262%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45577279%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45577301%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45577316%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45577325%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45577333%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45577382%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45577422%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45577432%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45577435%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45577445%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45577456%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45577483%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45577504%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45577659%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45577720%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45700273%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45700275%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45700414%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45700417%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45700430%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45700435%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45700471%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45700497%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45700508%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45700574%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45700599%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45700609%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45700630%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45700649%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45700661%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45700695%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45700697%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45700725%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45700741%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45700747%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45700758%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45777156%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45827709%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45827751%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r46369746%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r46369772%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r46369904%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r46369907%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r46369910%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r46370014%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r46379499%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r46379737%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r46379741%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r46379792%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r46526988%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r46651271%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r46651370%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r46652323%22%2C%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r46652355%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%20398878f1a3d4b1d7943e9c9b22fec82af9957928%20content/data-loading.md%20294%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45577382%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20is%20the%20first%20time%20we%27ve%20mentioned%20React%20in%20this%20guide%21%20Also%2C%20should%20we%20call%20out%20that%20you%20should%20try%20to%20centralize%20where%20you%20access%20stores%2C%20just%20like%20collections%3F%20Also%2C%20this%20could%20probably%20boil%20down%20to%20just%20%5C%22access%20stores%20the%20same%20way%20we%20told%20you%20to%20access%20collections%20above%5C%22%22%2C%20%22created_at%22%3A%20%222015-11-23T07%3A42%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yeah%20I%20sort%20of%20did%2C%20but%20badly%2C%20will%20fix.%22%2C%20%22created_at%22%3A%20%222015-11-23T07%3A44%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22PS%20should%20I%20leave%20react%20out%3F%22%2C%20%22created_at%22%3A%20%222015-11-23T07%3A44%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-04T05%3A49%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20content/data-loading.md%3AL1-557%22%7D%2C%20%22Pull%20398878f1a3d4b1d7943e9c9b22fec82af9957928%20content/data-loading.md%20290%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45577325%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22We%20should%20figure%20out%20how%20we%20are%20supposed%20to%20link%20to%20sections%20of%20other%20articles.%22%2C%20%22created_at%22%3A%20%222015-11-23T07%3A41%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20believe%20this%20is%20how%20you%20do%20it%20but%20I%20totally%20haven%27t%20tested%20it.%22%2C%20%22created_at%22%3A%20%222015-11-23T07%3A44%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-24T06%3A30%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20content/data-loading.md%3AL1-557%22%7D%2C%20%22Pull%20398878f1a3d4b1d7943e9c9b22fec82af9957928%20content/data-loading.md%20178%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45576941%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20should%20be%20like%20an%20indented%20list%20or%20something%2C%20right%3F%20AFAIK%20markdown%20won%27t%20recognize%20this%20markup.%22%2C%20%22created_at%22%3A%20%222015-11-23T07%3A31%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hmm%2C%20is%20this%20better%3F%22%2C%20%22created_at%22%3A%20%222015-11-24T06%3A28%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-12-02T02%3A12%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20content/data-loading.md%3AL1-557%22%7D%2C%20%22Pull%20398878f1a3d4b1d7943e9c9b22fec82af9957928%20content/data-loading.md%20153%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45576986%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%27d%20say%20this%20is%20specifically%20%5C%22Reactively%20changing%20subscription%20arguments%5C%22%22%2C%20%22created_at%22%3A%20%222015-11-23T07%3A32%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-24T06%3A26%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20content/data-loading.md%3AL1-557%22%7D%2C%20%22Pull%20398878f1a3d4b1d7943e9c9b22fec82af9957928%20content/data-loading.md%20111%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45576734%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22You%20could%20also%20use%20a%20subset%20of%20the%20query%2C%20but%20perhaps%20that%27s%20not%20really%20important%3F%22%2C%20%22created_at%22%3A%20%222015-11-23T07%3A26%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yeah%2C%20I%20think%20I%27ll%20avoid%20over%20qualifying%22%2C%20%22created_at%22%3A%20%222015-11-24T06%3A24%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-24T06%3A24%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20content/data-loading.md%3AL1-557%22%7D%2C%20%22Pull%20398878f1a3d4b1d7943e9c9b22fec82af9957928%20content/data-loading.md%2087%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45576641%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22It%27s%20not%20clear%20here%20why%20%5C%22action%20at%20a%20distance%5C%22%20might%20happen%20-%20I%20think%20we%20should%20call%20out%20that%20making%20a%20subscription%20means%20potentially%20all%20queries%20on%20that%20collection%20could%20get%20new%20data.%22%2C%20%22created_at%22%3A%20%222015-11-23T07%3A23%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20think%20this%20is%20better%20now%22%2C%20%22created_at%22%3A%20%222015-11-24T06%3A21%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-12-02T02%3A12%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20content/data-loading.md%3AL1-557%22%7D%2C%20%22Pull%20398878f1a3d4b1d7943e9c9b22fec82af9957928%20content/data-loading.md%20175%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45576966%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%5C%22tells%20it%20to%20re-run%20itself%5C%22%20-%3E%20%5C%22Marks%20it%20so%20that%20it%20is%20re-run%20in%20the%20next%20flush%20cycle%5C%22%22%2C%20%22created_at%22%3A%20%222015-11-23T07%3A32%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-24T06%3A27%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20content/data-loading.md%3AL1-557%22%7D%2C%20%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/97%23issuecomment-158869667%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Funny%2C%20I%20wrote%20a%20Medium%20post%20on%20a%20similar%20topic%20a%20while%20ago%3A%20https%3A//medium.com/%40stubailo/data-flow-from-the-database-to-the-ui-three-layers-of-meteor-d5e208b466c3%5Cr%5Cn%5Cr%5CnThis%20article%20was%20one%20of%20the%20reasons%20I%20wanted%20a%20complete%20guide%20in%20the%20first%20place%20-%20so%20that%20we%20wouldn%27t%20have%20to%20write%20a%20bunch%20of%20blog%20posts%20like%20that.%20Really%20excited%20that%20it%27s%20actually%20shaping%20up%21%22%2C%20%22created_at%22%3A%20%222015-11-23T07%3A35%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-12-02T02%3A12%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20think%20this%20one%20is%20ready%20to%20go%20too.%22%2C%20%22created_at%22%3A%20%222015-12-04T06%3A17%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222015-12-04T08%3A22%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22LGTM%21%20Awesome%20work%2C%20ship%20itttt%20%3Ashipit%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-04T08%3A22%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20398878f1a3d4b1d7943e9c9b22fec82af9957928%20content/data-loading.md%20419%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45577659%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%27d%20phrase%20this%20in%20a%20use-case%20way%20-%20%5C%22Writing%20custom%20publications%20with%20the%20low-level%20publication%20API%5C%22%20or%20something%3F%22%2C%20%22created_at%22%3A%20%222015-11-23T07%3A49%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-24T06%3A31%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20content/data-loading.md%3AL1-557%22%7D%2C%20%22Pull%20398878f1a3d4b1d7943e9c9b22fec82af9957928%20content/data-loading.md%20161%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45576909%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Why%20are%20we%20putting%20a%20route%20parameter%20on%20state%20rather%20than%20using%20it%20from%20the%20router%20directly%3F%22%2C%20%22created_at%22%3A%20%222015-11-23T07%3A30%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22We%20use%20it%20at%20other%20places%20in%20the%20template.%20I%20could%20access%20it%20directly%20in%20this%20autorun%20twice%20though.%22%2C%20%22created_at%22%3A%20%222015-11-23T07%3A39%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yeah%20I%27d%20say%20that%20in%20this%20code%20sample%20it%27s%20just%20confusing.%20Plus%2C%20it%27s%20easy%20to%20end%20up%20with%20bugs%20if%20you%27re%20syncing%20state%20around%20like%20this.%22%2C%20%22created_at%22%3A%20%222015-12-02T02%3A14%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222015-12-02T05%3A54%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20content/data-loading.md%3AL1-557%22%7D%2C%20%22Pull%20398878f1a3d4b1d7943e9c9b22fec82af9957928%20content/data-loading.md%20316%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45577483%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20don%27t%20know%20if%20we%20should%20have%20long%20code%20samples%20that%20people%20shouldn%27t%20be%20using%20-%20I%27ve%20definitely%20seen%20people%20use%20code%20marked%20as%20%5C%22do%20not%20use%5C%22%20before%3F%22%2C%20%22created_at%22%3A%20%222015-11-23T07%3A45%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22Marked%20%60jsbad%60%22%2C%20%22created_at%22%3A%20%222015-11-24T06%3A30%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-24T06%3A30%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20content/data-loading.md%3AL1-557%22%7D%2C%20%22Pull%20398878f1a3d4b1d7943e9c9b22fec82af9957928%20content/data-loading.md%20236%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45577174%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Isn%27t%20this%20potentially%20really%20inefficient%3F%20Like%20as%20far%20as%20I%20know%2C%20the%20client%20will%20get%20rid%20of%20all%20of%20the%20old%20documents%20and%20send%20all%20of%20them%20over%20again%3F%20Or%20does%20the%20merge%20box%20handle%20it%20somehow%3F%22%2C%20%22created_at%22%3A%20%222015-11-23T07%3A37%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22mergebox%2B%2B%22%2C%20%22created_at%22%3A%20%222015-11-23T07%3A41%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-24T06%3A28%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20content/data-loading.md%3AL1-557%22%7D%2C%20%22Pull%20398878f1a3d4b1d7943e9c9b22fec82af9957928%20content/data-loading.md%20312%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45577432%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20feel%20like%20it%27s%20weird%20that%20this%20comes%20after%20client-side%20state...%20it%27s%20kind%20of%20a%20weird%20section%20in%20between%20a%20bunch%20of%20sections%20about%20server%20data%20and%20publications.%22%2C%20%22created_at%22%3A%20%222015-11-23T07%3A44%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yeah%2C%20we%20are%20going%20to%20move%20it%20%28somewhere%3F%29.%20I%20just%20wrote%20it%20anyway%22%2C%20%22created_at%22%3A%20%222015-11-23T07%3A45%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-24T06%3A30%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20content/data-loading.md%3AL1-557%22%7D%2C%20%22Pull%20398878f1a3d4b1d7943e9c9b22fec82af9957928%20content/data-loading.md%20275%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45577279%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60function%20getDimensions%60%20instead%20of%20arrow%20function.%22%2C%20%22created_at%22%3A%20%222015-11-23T07%3A40%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-24T06%3A29%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20content/data-loading.md%3AL1-557%22%7D%2C%20%22Pull%20398878f1a3d4b1d7943e9c9b22fec82af9957928%20content/data-loading.md%20252%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45577234%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20think%20in%20these%20cases%20we%20should%20define%20a%20specific%20word%20-%20we%20should%20always%20call%20it%20either%20%5C%22server%20data%5C%22%2C%20%5C%22persistent%20data%5C%22%2C%20or%20%5C%22shared%20data%5C%22.%22%2C%20%22created_at%22%3A%20%222015-11-23T07%3A39%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22Oh%20I%20actually%20wanted%20the%20two%20definitions%20here%20because%20I%20wanted%20to%20emphasise%20there%20are%20two%20reasons%20to%20use%20a%20pub%20--%20either%20b/c%20the%20data%20needs%20to%20persist%2C%20or%20is%20shared.%22%2C%20%22created_at%22%3A%20%222015-11-23T07%3A43%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-12-02T02%3A12%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20content/data-loading.md%3AL1-557%22%7D%2C%20%22Pull%20398878f1a3d4b1d7943e9c9b22fec82af9957928%20content/data-loading.md%20250%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45577213%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Perhaps%20this%20could%20be%20rephrased%20as%20%5C%22Client-side%20data%20management%3A%20Stores%5C%22%22%2C%20%22created_at%22%3A%20%222015-11-23T07%3A38%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-24T06%3A29%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20content/data-loading.md%3AL1-557%22%7D%2C%20%22Pull%20398878f1a3d4b1d7943e9c9b22fec82af9957928%20content/data-loading.md%20456%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45577720%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Seems%20like%20the%20above%20two%20points%20would%20go%20in%20a%20%5C%22performance%5C%22%20article%3F%22%2C%20%22created_at%22%3A%20%222015-11-23T07%3A50%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-25T04%3A05%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20content/data-loading.md%3AL1-557%22%7D%2C%20%22Pull%20398878f1a3d4b1d7943e9c9b22fec82af9957928%20content/data-loading.md%2055%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45576527%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20is%20an%20_important%20point_%20-%20we%20should%20call%20out%20somewhere%20big%20that%20if%20you%20don%27t%20return%20an%20array%2C%20or%20call%20%60this.ready%60%2C%20the%20publication%20will%20_never_%20be%20marked%20ready%2C%20which%20results%20in%20all%20kinds%20of%20crappy%20bugs.%20%28Even%20returning%20%60null%60%20is%20not%20enough%2C%20lol.%20I%20think%20we%20should%20fix%20this%20somehow%20in%20a%20future%20version%20of%20Meteor.%29%22%2C%20%22created_at%22%3A%20%222015-11-23T07%3A19%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22Also%2C%20we%20should%20mention%20what%20it%20means%20for%20a%20subscription%20to%20be%20ready%20-%20namely%2C%20this%20is%20used%20to%20fire%20the%20%60ready%60%20callback%20on%20the%20client.%22%2C%20%22created_at%22%3A%20%222015-11-23T07%3A20%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27m%20not%20sure%20why%20we%20even%20have%20the%20same%20API%20for%20publications%20that%20return%20cursors.%20Why%20not%20just%20%60Meteor.publishCursor%60%3F%20--%20then%20if%20it%20doesn%27t%20return%20anything%2C%20you%20know%20it%27s%20done.%5Cr%5Cn%5Cr%5CnOverloading%20%60Meteor.publish%60%20was%20a%20mistake%2C%20IMO.%22%2C%20%22created_at%22%3A%20%222015-11-23T07%3A22%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20strictly%20agree%3B%20I%27m%20just%20saying%20in%20today%27s%20world%2C%20this%20is%20a%20very%20important%20fact%20to%20know%2C%20and%20a%20lot%20of%20people%20end%20up%20with%20bugs%20because%20of%20it.%22%2C%20%22created_at%22%3A%20%222015-12-02T02%3A10%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22This%20now%20says%3A%5Cr%5Cn%5Cr%5Cn%3E%20It%27s%20important%20to%20know%20that%20if%20you%20don%27t%20return%20a%20cursor%20from%20the%20publication%20or%20call%20%60this.ready%28%29%60%2C%20the%20user%27s%20subscription%20will%20never%20become%20ready%2C%20and%20they%20will%20likely%20see%20a%20loading%20state%20forever.%5Cr%5Cn%5Cr%5CnIs%20this%20OK%20by%20you%3F%22%2C%20%22created_at%22%3A%20%222015-12-02T06%3A00%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222015-12-03T09%3A06%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20content/data-loading.md%3AL1-557%22%7D%2C%20%22Pull%20398878f1a3d4b1d7943e9c9b22fec82af9957928%20content/data-loading.md%20288%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45577301%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20could%20be%20phrased%20as%20-%20it%20diffs%20the%20fields%20and%20tracks%20changes%20on%20each%20field%20individually.%22%2C%20%22created_at%22%3A%20%222015-11-23T07%3A41%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-24T06%3A30%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20content/data-loading.md%3AL1-557%22%7D%2C%20%22Pull%20398878f1a3d4b1d7943e9c9b22fec82af9957928%20content/data-loading.md%20121%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45576786%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Although%20you%20don%27t%20want%20to%20pass%20it%20through%20as%20an%20argument%20everywhere%2C%20I%27d%20still%20recommend%20being%20judicious%20with%20where%20you%20use%20it%2C%20since%20it%20could%20make%20your%20components%20more%20annoying%20to%20test.%22%2C%20%22created_at%22%3A%20%222015-11-23T07%3A27%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-24T06%3A25%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20content/data-loading.md%3AL1-557%22%7D%2C%20%22Pull%20398878f1a3d4b1d7943e9c9b22fec82af9957928%20content/data-loading.md%20123%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45576821%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Should%20we%20change%20this%3F%20I%20don%27t%20think%20there%20is%20actually%20any%20performance%20benefit%20to%20fetching%20down%20the%20tree%2C%20since%20we%20can%20just%20pass%20the%20cursor%20through.%22%2C%20%22created_at%22%3A%20%222015-11-23T07%3A28%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22We%20do%20something%20zany%20like%5Cr%5Cn%5Cr%5Cn%60%60%60%5Cr%5CnlistShowPage%5Cr%5Cn%20%20%20%5C%5C--B%20here%20the%20data%20context%20is%20listId%5Cr%5Cn%20%20%20%20%20%20%20%20%5C%5C--%20C%20here%27s%20it%27s%20list.todos%28%29%5Cr%5Cn%60%60%60%5Cr%5Cn%5Cr%5CnBecause%20we%20don%27t%20want%20C%20re-rendering%20when%20%60list.incompleteCount%60%20changes%2C%20we%20don%27t%20do%20the%20obvious%20thing%20and%20make%20the%20d.c.%20%60%7Blist%2C%20todos%3A%20list.todos%28%29%7D%60%20at%20B.%5Cr%5Cn%5Cr%5CnThere%27s%20actually%20no%20good%20way%20to%20work%20around%20this%20situation%2C%20because%20you%20can%27t%20control%20reactivity%20per-field%20in%20MM.%5Cr%5Cn%5Cr%5Cn%5Cr%5Cn%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-11-23T07%3A38%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22See%20https%3A//github.com/meteor/todos/pull/56%22%2C%20%22created_at%22%3A%20%222015-12-04T06%3A15%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-04T06%3A16%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20content/data-loading.md%3AL1-557%22%7D%2C%20%22Pull%20398878f1a3d4b1d7943e9c9b22fec82af9957928%20content/data-loading.md%20103%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45576682%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Actually%2C%20Meteor.subscribe%20would%20also%20tear%20down%20the%20subscription%20because%20of%20how%20autorun%20works%2C%20but%20the%20real%20benefit%20is%20being%20able%20to%20use%20%60Template.instance%28%29.subscriptionsReady%28%29%60.%20%28This%20was%20designed%20to%20replace%20%60waitOn%60%20in%20Iron%20Router%20%3A%5D%20%29%22%2C%20%22created_at%22%3A%20%222015-11-23T07%3A24%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22Oh%20right%2C%20%3Ablush%3A%22%2C%20%22created_at%22%3A%20%222015-11-23T07%3A26%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-24T06%3A21%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20content/data-loading.md%3AL1-557%22%7D%2C%20%22Pull%20398878f1a3d4b1d7943e9c9b22fec82af9957928%20content/data-loading.md%20127%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45576849%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3E%20not%20subscribe%20to%20a%20subscription%5Cr%5Cn%5Cr%5CnI%27m%20not%20sure%20what%20this%20means%20-%20perhaps%20you%20mean%20subscribing%20outside%20of%20a%20template%3F%22%2C%20%22created_at%22%3A%20%222015-11-23T07%3A29%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22yeah%20I%20think%20I%20mean%20%5C%22not%20subscribe%20inside%20a%20template%5C%22%22%2C%20%22created_at%22%3A%20%222015-11-23T07%3A38%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-24T06%3A26%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20content/data-loading.md%3AL1-557%22%7D%2C%20%22Pull%20398878f1a3d4b1d7943e9c9b22fec82af9957928%20content/data-loading.md%20200%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45577098%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Yikes%21%20Is%20there%20at%20least%20somewhere%20we%20can%20link%20to%20that%20tells%20you%20how%20to%20do%20it%20correctly%3F%20Or%20is%20it%20literally%20impossible%3F%22%2C%20%22created_at%22%3A%20%222015-11-23T07%3A36%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22Literally%20impossible%20without%20hacks%20like%20https%3A//github.com/percolatestudio/find-from-publication%22%2C%20%22created_at%22%3A%20%222015-11-23T07%3A40%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22Oh%20boy.%20I%20see%20what%20you%27re%20saying%20-%20the%20limit%20has%20to%20be%20on%20the%20server%2C%20but%20that%20information%20is%20lost%20when%20publishing%20unless%20you%20can%20isolate%20the%20data%20from%20the%20publication.%20That%27s%20quite%20unfortunate...%20what%20about%20fetching%20data%20with%20a%20method%3F%20That%20would%20work%2C%20although%20would%20be%20super%20jank%22%2C%20%22created_at%22%3A%20%222015-11-24T18%3A50%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22Should%20we%20mention%20that%20you%20should%20use%20a%20method%20or%20look%20at%20FFP%20here%20do%20you%20think%3F%22%2C%20%22created_at%22%3A%20%222015-11-25T04%3A04%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222015-12-04T05%3A52%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20content/data-loading.md%3AL1-557%22%7D%2C%20%22Pull%20398878f1a3d4b1d7943e9c9b22fec82af9957928%20content/data-loading.md%20109%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45576714%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%5C%22Subscribing%20to%20data%20puts%20it%20in%20your%20client-side%20collections.%20To%20use%20the%20data%20in%20your%20templates%2C%20you%20need%20to%20query...%5C%22%22%2C%20%22created_at%22%3A%20%222015-11-23T07%3A25%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22Better%2C%20thanks%22%2C%20%22created_at%22%3A%20%222015-11-24T06%3A24%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-24T06%3A24%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20content/data-loading.md%3AL1-557%22%7D%2C%20%22Pull%20398878f1a3d4b1d7943e9c9b22fec82af9957928%20content/data-loading.md%2073%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45576576%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20should%20be%20co-located%20with%20the%20code.%20Perhaps%20this%20could%20even%20be%20a%20comment.%20We%27ll%20have%20a%20whole%20bit%20on%20this%20in%20the%20security%20article.%22%2C%20%22created_at%22%3A%20%222015-11-23T07%3A21%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22Bump%21%22%2C%20%22created_at%22%3A%20%222015-12-02T02%3A10%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20changed%20this.%22%2C%20%22created_at%22%3A%20%222015-12-02T06%3A00%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-02T06%3A00%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20content/data-loading.md%3AL1-557%22%7D%2C%20%22Pull%20398878f1a3d4b1d7943e9c9b22fec82af9957928%20content/data-loading.md%20248%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/97%23discussion_r45577184%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Weird%20formatting%2C%20screws%20up%20code%20highlighting%20below%20this%20point.%22%2C%20%22created_at%22%3A%20%222015-11-23T07%3A37%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20think%20there%27s%20an%20extra%20%5C%22%60%5C%22%20in%20there%20somehow%22%2C%20%22created_at%22%3A%20%222015-11-23T07%3A42%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-24T06%3A28%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20content/data-loading.md%3AL1-557%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/stubailo%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/stubailo'><img src='https://avatars.githubusercontent.com/u/448783?v=3' width=34 height=34></a>

- [x] <a href='#crh-comment-Pull 398878f1a3d4b1d7943e9c9b22fec82af9957928 content/data-loading.md 55'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/97#discussion_r45576527'>File: content/data-loading.md:L1-557</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> This is an _important point_ - we should call out somewhere big that if you don't return an array, or call `this.ready`, the publication will _never_ be marked ready, which results in all kinds of crappy bugs. (Even returning `null` is not enough, lol. I think we should fix this somehow in a future version of Meteor.)
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Also, we should mention what it means for a subscription to be ready - namely, this is used to fire the `ready` callback on the client.
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> I'm not sure why we even have the same API for publications that return cursors. Why not just `Meteor.publishCursor`? -- then if it doesn't return anything, you know it's done.
Overloading `Meteor.publish` was a mistake, IMO.
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> I strictly agree; I'm just saying in today's world, this is a very important fact to know, and a lot of people end up with bugs because of it.
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> This now says:
> It's important to know that if you don't return a cursor from the publication or call `this.ready()`, the user's subscription will never become ready, and they will likely see a loading state forever.
Is this OK by you?
- [x] <a href='#crh-comment-Pull 398878f1a3d4b1d7943e9c9b22fec82af9957928 content/data-loading.md 73'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/97#discussion_r45576576'>File: content/data-loading.md:L1-557</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> This should be co-located with the code. Perhaps this could even be a comment. We'll have a whole bit on this in the security article.
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Bump!
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> I changed this.
- [x] <a href='#crh-comment-Pull 398878f1a3d4b1d7943e9c9b22fec82af9957928 content/data-loading.md 87'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/97#discussion_r45576641'>File: content/data-loading.md:L1-557</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> It's not clear here why "action at a distance" might happen - I think we should call out that making a subscription means potentially all queries on that collection could get new data.
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> I think this is better now
- [x] <a href='#crh-comment-Pull 398878f1a3d4b1d7943e9c9b22fec82af9957928 content/data-loading.md 103'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/97#discussion_r45576682'>File: content/data-loading.md:L1-557</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Actually, Meteor.subscribe would also tear down the subscription because of how autorun works, but the real benefit is being able to use `Template.instance().subscriptionsReady()`. (This was designed to replace `waitOn` in Iron Router :] )
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> Oh right, :blush:
- [x] <a href='#crh-comment-Pull 398878f1a3d4b1d7943e9c9b22fec82af9957928 content/data-loading.md 109'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/97#discussion_r45576714'>File: content/data-loading.md:L1-557</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> "Subscribing to data puts it in your client-side collections. To use the data in your templates, you need to query..."
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> Better, thanks
- [x] <a href='#crh-comment-Pull 398878f1a3d4b1d7943e9c9b22fec82af9957928 content/data-loading.md 111'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/97#discussion_r45576734'>File: content/data-loading.md:L1-557</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> You could also use a subset of the query, but perhaps that's not really important?
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> Yeah, I think I'll avoid over qualifying
- [x] <a href='#crh-comment-Pull 398878f1a3d4b1d7943e9c9b22fec82af9957928 content/data-loading.md 121'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/97#discussion_r45576786'>File: content/data-loading.md:L1-557</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Although you don't want to pass it through as an argument everywhere, I'd still recommend being judicious with where you use it, since it could make your components more annoying to test.
- [x] <a href='#crh-comment-Pull 398878f1a3d4b1d7943e9c9b22fec82af9957928 content/data-loading.md 123'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/97#discussion_r45576821'>File: content/data-loading.md:L1-557</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Should we change this? I don't think there is actually any performance benefit to fetching down the tree, since we can just pass the cursor through.
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> We do something zany like
```
listShowPage
\--B here the data context is listId
\-- C here's it's list.todos()
```
Because we don't want C re-rendering when `list.incompleteCount` changes, we don't do the obvious thing and make the d.c. `{list, todos: list.todos()}` at B.
There's actually no good way to work around this situation, because you can't control reactivity per-field in MM.
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> See https://github.com/meteor/todos/pull/56
- [x] <a href='#crh-comment-Pull 398878f1a3d4b1d7943e9c9b22fec82af9957928 content/data-loading.md 127'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/97#discussion_r45576849'>File: content/data-loading.md:L1-557</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> > not subscribe to a subscription
I'm not sure what this means - perhaps you mean subscribing outside of a template?
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> yeah I think I mean "not subscribe inside a template"
- [x] <a href='#crh-comment-Pull 398878f1a3d4b1d7943e9c9b22fec82af9957928 content/data-loading.md 161'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/97#discussion_r45576909'>File: content/data-loading.md:L1-557</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Why are we putting a route parameter on state rather than using it from the router directly?
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> We use it at other places in the template. I could access it directly in this autorun twice though.
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Yeah I'd say that in this code sample it's just confusing. Plus, it's easy to end up with bugs if you're syncing state around like this.
- [x] <a href='#crh-comment-Pull 398878f1a3d4b1d7943e9c9b22fec82af9957928 content/data-loading.md 178'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/97#discussion_r45576941'>File: content/data-loading.md:L1-557</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> This should be like an indented list or something, right? AFAIK markdown won't recognize this markup.
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> Hmm, is this better?
- [x] <a href='#crh-comment-Pull 398878f1a3d4b1d7943e9c9b22fec82af9957928 content/data-loading.md 175'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/97#discussion_r45576966'>File: content/data-loading.md:L1-557</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> "tells it to re-run itself" -> "Marks it so that it is re-run in the next flush cycle"
- [x] <a href='#crh-comment-Pull 398878f1a3d4b1d7943e9c9b22fec82af9957928 content/data-loading.md 153'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/97#discussion_r45576986'>File: content/data-loading.md:L1-557</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> I'd say this is specifically "Reactively changing subscription arguments"
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/97#issuecomment-158869667'>General Comment</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Funny, I wrote a Medium post on a similar topic a while ago: https://medium.com/@stubailo/data-flow-from-the-database-to-the-ui-three-layers-of-meteor-d5e208b466c3
This article was one of the reasons I wanted a complete guide in the first place - so that we wouldn't have to write a bunch of blog posts like that. Really excited that it's actually shaping up!
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> :+1:<a href='#crh-update-none'></a>
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> I think this one is ready to go too.
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> :+1:
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> LGTM! Awesome work, ship itttt :shipit:
- [x] <a href='#crh-comment-Pull 398878f1a3d4b1d7943e9c9b22fec82af9957928 content/data-loading.md 200'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/97#discussion_r45577098'>File: content/data-loading.md:L1-557</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Yikes! Is there at least somewhere we can link to that tells you how to do it correctly? Or is it literally impossible?
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> Literally impossible without hacks like https://github.com/percolatestudio/find-from-publication
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Oh boy. I see what you're saying - the limit has to be on the server, but that information is lost when publishing unless you can isolate the data from the publication. That's quite unfortunate... what about fetching data with a method? That would work, although would be super jank
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> Should we mention that you should use a method or look at FFP here do you think?
- [x] <a href='#crh-comment-Pull 398878f1a3d4b1d7943e9c9b22fec82af9957928 content/data-loading.md 236'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/97#discussion_r45577174'>File: content/data-loading.md:L1-557</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Isn't this potentially really inefficient? Like as far as I know, the client will get rid of all of the old documents and send all of them over again? Or does the merge box handle it somehow?
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> mergebox++
- [x] <a href='#crh-comment-Pull 398878f1a3d4b1d7943e9c9b22fec82af9957928 content/data-loading.md 248'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/97#discussion_r45577184'>File: content/data-loading.md:L1-557</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Weird formatting, screws up code highlighting below this point.
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> I think there's an extra "`" in there somehow
- [x] <a href='#crh-comment-Pull 398878f1a3d4b1d7943e9c9b22fec82af9957928 content/data-loading.md 250'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/97#discussion_r45577213'>File: content/data-loading.md:L1-557</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Perhaps this could be rephrased as "Client-side data management: Stores"
- [x] <a href='#crh-comment-Pull 398878f1a3d4b1d7943e9c9b22fec82af9957928 content/data-loading.md 252'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/97#discussion_r45577234'>File: content/data-loading.md:L1-557</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> I think in these cases we should define a specific word - we should always call it either "server data", "persistent data", or "shared data".
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> Oh I actually wanted the two definitions here because I wanted to emphasise there are two reasons to use a pub -- either b/c the data needs to persist, or is shared.
- [x] <a href='#crh-comment-Pull 398878f1a3d4b1d7943e9c9b22fec82af9957928 content/data-loading.md 275'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/97#discussion_r45577279'>File: content/data-loading.md:L1-557</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> `function getDimensions` instead of arrow function.
- [x] <a href='#crh-comment-Pull 398878f1a3d4b1d7943e9c9b22fec82af9957928 content/data-loading.md 288'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/97#discussion_r45577301'>File: content/data-loading.md:L1-557</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> This could be phrased as - it diffs the fields and tracks changes on each field individually.
- [x] <a href='#crh-comment-Pull 398878f1a3d4b1d7943e9c9b22fec82af9957928 content/data-loading.md 290'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/97#discussion_r45577325'>File: content/data-loading.md:L1-557</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> We should figure out how we are supposed to link to sections of other articles.
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> I believe this is how you do it but I totally haven't tested it.
- [x] <a href='#crh-comment-Pull 398878f1a3d4b1d7943e9c9b22fec82af9957928 content/data-loading.md 294'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/97#discussion_r45577382'>File: content/data-loading.md:L1-557</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> This is the first time we've mentioned React in this guide! Also, should we call out that you should try to centralize where you access stores, just like collections? Also, this could probably boil down to just "access stores the same way we told you to access collections above"
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> Yeah I sort of did, but badly, will fix.
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> PS should I leave react out?
- [x] <a href='#crh-comment-Pull 398878f1a3d4b1d7943e9c9b22fec82af9957928 content/data-loading.md 312'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/97#discussion_r45577432'>File: content/data-loading.md:L1-557</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> I feel like it's weird that this comes after client-side state... it's kind of a weird section in between a bunch of sections about server data and publications.
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> Yeah, we are going to move it (somewhere?). I just wrote it anyway
- [x] <a href='#crh-comment-Pull 398878f1a3d4b1d7943e9c9b22fec82af9957928 content/data-loading.md 316'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/97#discussion_r45577483'>File: content/data-loading.md:L1-557</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> I don't know if we should have long code samples that people shouldn't be using - I've definitely seen people use code marked as "do not use" before?
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> Marked `jsbad`
- [x] <a href='#crh-comment-Pull 398878f1a3d4b1d7943e9c9b22fec82af9957928 content/data-loading.md 419'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/97#discussion_r45577659'>File: content/data-loading.md:L1-557</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> I'd phrase this in a use-case way - "Writing custom publications with the low-level publication API" or something?
- [x] <a href='#crh-comment-Pull 398878f1a3d4b1d7943e9c9b22fec82af9957928 content/data-loading.md 456'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/97#discussion_r45577720'>File: content/data-loading.md:L1-557</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Seems like the above two points would go in a "performance" article?


<a href='https://www.codereviewhub.com/meteor/guide/pull/97?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/meteor/guide/pull/97?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/meteor/guide/pull/97?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/meteor/guide/pull/97'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>