### PR TITLE
Replace the GitHub link to ActiveRoute with an Atmosphere link

### DIFF
--- a/broken-content/routing.md
+++ b/broken-content/routing.md
@@ -103,7 +103,7 @@ So in our example of the list page form the Todos app, we access the current lis
 
 One situation where it is sensible to access the global `FlowRouter` singleton to access the current route's information deeper in the component hierarchy is when rendering links via a navigation component. It's often required to highlight the "active" route in some way (this is the route or section of the site that the user is currently looking at).
 
-A convenient package for this is [`zimme:active-route`](https://github.com/zimme/meteor-active-route):
+A convenient package for this is [`zimme:active-route`](https://atmospherejs.com/zimme/active-route):
 
 ```bash
 meteor add zimme:active-route


### PR DESCRIPTION
Atmosphere pages look more useful for most Meteor users (starring, activity graph, downloads, etc)
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/meteor/guide/pull/124?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/meteor/guide/pull/124'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>