### PR TITLE
Minor case change

### DIFF
--- a/content/collections.md
+++ b/content/collections.md
@@ -25,7 +25,7 @@ In this article, we'll look closely at how collections work in various places in
 
 When you create a collection on the server:
 ```js
-Todos = new Mongo.Collection('Todos');
+Todos = new Mongo.Collection('todos');
 ```
 
 You are creating a collection within MongoDB itself, and an interface to that collection to be used on the server. It's a fairly straightforward layer on top of the underlying Node MongoDB driver, but with a synchronous (fibers-based) API:
@@ -43,7 +43,7 @@ console.log(todo);
 
 On the client, when you write the same line:
 ```js
-Todos = new Mongo.Collection('Todos');
+Todos = new Mongo.Collection('todos');
 ```
 
 It does something totally different!


### PR DESCRIPTION
Pretty much every piece of documentation and tutorial I've seen uses `camelCase` or `under_score` formatting for mongodb collections. Just suggesting this for consistency.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/meteor/guide/pull/126%23issuecomment-162107397%22%2C%20%22https%3A//github.com/meteor/guide/pull/126%23issuecomment-162107594%22%2C%20%22https%3A//github.com/meteor/guide/pull/126%23issuecomment-162107807%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/126%23issuecomment-162107397%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Yeah%20we%27re%20making%20an%20explicit%20recommendation%20that%20this%20is%20better%20because%20it%27s%20consistent%20with%20the%20actual%20JavaScript%20symbol%20name.%20We%20can%20have%20a%20more%20in%20depth%20discussion%20about%20it%20but%20I%27m%20not%20sure%20it%27s%20super%20important.%22%2C%20%22created_at%22%3A%20%222015-12-04T23%3A14%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ah%20I%20see.%20Carry%20on%20then%21%22%2C%20%22created_at%22%3A%20%222015-12-04T23%3A15%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12532733%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ffxsam%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yep%2C%20there%20will%20be%20more%20on%20this%20in%20the%20code%20style%20and%20application%20structure%20articles.%20We%20basically%20have%20recommendations%20for%20how%20to%20name%20every%20single%20thing.%20Not%20that%20you%20need%20to%20follow%20them%2C%20but%20it%27s%20good%20to%20have%20a%20default%20option%20%3A%5D%22%2C%20%22created_at%22%3A%20%222015-12-04T23%3A17%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/126#issuecomment-162107397'>General Comment</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Yeah we're making an explicit recommendation that this is better because it's consistent with the actual JavaScript symbol name. We can have a more in depth discussion about it but I'm not sure it's super important.
- <a href='https://github.com/ffxsam'><img border=0 src='https://avatars.githubusercontent.com/u/12532733?v=3' height=16 width=16'></a> Ah I see. Carry on then!
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Yep, there will be more on this in the code style and application structure articles. We basically have recommendations for how to name every single thing. Not that you need to follow them, but it's good to have a default option :]


<a href='https://www.codereviewhub.com/meteor/guide/pull/126?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/meteor/guide/pull/126?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/meteor/guide/pull/126'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>