### PR TITLE
Links progress reference directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Articles complete](https://badge.waffle.io/meteor/guide.svg?label=ready&title=Articles%20Complete)](https://waffle.io/meteor/guide?label=article)
 
-We're tracking our progress using Waffle.io; see the board by clicking the badge above!
+We're tracking [our progress](https://waffle.io/meteor/guide?label=article) using Waffle.io.
 
 ---------
 


### PR DESCRIPTION
Instead of a text reference to the link. The indirection is unnecessary I think.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/meteor/guide/pull/135%23issuecomment-162707223%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/135%23issuecomment-162707223%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Makes%20sense%21%20I%20actually%20feel%20like%20the%20badge%20is%20pretty%20useless.%20Perhaps%20we%20should%20remove%20it%20entirely.%22%2C%20%22created_at%22%3A%20%222015-12-07T23%3A45%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/135#issuecomment-162707223'>General Comment</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Makes sense! I actually feel like the badge is pretty useless. Perhaps we should remove it entirely.


<a href='https://www.codereviewhub.com/meteor/guide/pull/135?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/meteor/guide/pull/135?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/meteor/guide/pull/135'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>