### PR TITLE
Blaze content

### DIFF
--- a/content/blaze.md
+++ b/content/blaze.md
@@ -455,6 +455,32 @@ It's not uncommon to want to reuse code between two otherwise unrelated componen
 <h3 id="composition">Composition</h3>
 If possible, it's usually best to try and abstract out the reusable part of the two components that need to share functionality. If you are used to following patterns to [create reusable components](#reusable-components), then it should be simple to reuse those components in many places. 
 
+For instance, suppose you have many places in your application where you need an input to blur itself when you click the "esc" key. If you were building a autocomplete widget that also wanted this functionality, you could compose a `blurringInput` inside your `autocompleteInput`:
+
+```html
+<template name="autocompleteInput">
+  {{> blurringInput name=name value=currentValue}}
+</template>
+```
+
+XXX: we are violating our own rule here and reading into the sub-component. But there's no real mechanism to pass through generic event handlers in Blaze
+  
+```js
+Template.autocompleteInput.helpers({
+  currentValue() {
+    // perform complex logic to determine the auto-complete's current text value
+  }
+});
+
+Template.autocompleteInput.events({
+  'change input': function(event, instance) {
+    // read the current value out of the input, potentially change the value
+  }
+});
+```
+
+By making the `blurringInput` flexible and resuable, we can avoid re-implementing functionality in the `autocompleteInput`.
+
 <h3 id="utility-libraries">Utility libraries</h3>
 It's usually best to keep your view layer as "skinny" as possible and contain a component to whatever specific task it specifically needs to do. If there's heavy lifting involved (such as complicated rendering logic), it often makes sense to abstract it out into a utility library that simply deals with the logic alone and doesn't deal with the Blaze system at all. 
 

--- a/content/blaze.md
+++ b/content/blaze.md
@@ -405,7 +405,7 @@ Template.listsShowPage.onRendered(function() {
 ```
 
 <h2 id="smart-components">Writing smart components with Blaze</h2>
-If your component needs to access state outside of its data context---for instance, data from the server via subscriptions or the the contents of client-side store, then you should be careful how you do that accessing. As discussed in the [data loading article](data-loading) you should be careful and considered in how use such smart components.
+If your component needs to access state outside of its data context---for instance, data from the server via subscriptions or the the contents of client-side store, then you should be careful how you do that accessing. As discussed in the [data loading](data-loading) and [UI](ui-ux#smart-components) articles you should be careful and considered in how use such smart components.
 
 To begin with, all of the rules of thumb about reusable components apply to smart components. In addition:
 

--- a/content/blaze.md
+++ b/content/blaze.md
@@ -9,7 +9,7 @@ After reading this guide, you'll know:
 3. How the Blaze rendering engine works under the hood and some techniques to best use it.
 4. How to test Blaze templates.
 
-Blaze is Meteor's built in reactive rendering library. Using templates written in [Spacebars](https://github.com/meteor/meteor/blob/devel/packages/spacebars/README.md), a variant of [Handlebars](http://handlebarsjs.com) designed to take advantage of [Tracker](https://github.com/meteor/meteor/tree/devel/packages/tracker), Meteor's reactivity system.
+Blaze is Meteor's built in reactive rendering library. Using templates written in [Spacebars](https://github.com/meteor/meteor/blob/devel/packages/spacebars/README.md), a variant of [Handlebars](http://handlebarsjs.com) designed to take advantage of [Tracker](https://github.com/meteor/meteor/tree/devel/packages/tracker), Meteor's reactivity system, you can build components that are rendered by the Blaze library.
 
 Blaze is not required to built applications in Meteor---you can equally use [React](http://react-in-meteor.readthedocs.org/en/latest/) or [Angular](http://www.angular-meteor.com), however this guide will take you through best practice in building an application in Blaze.
 
@@ -35,11 +35,11 @@ As an example, consider the `todosItem` template from the Todos example app:
 </template>
 ```
 
-In this example, the template is rendered with an object with key `todo` as data context (we'll see below how to enforce that). We access the properties of the `todo`  using the mustache tag, such as `{{todo.text}}`. The default behaviour is to render that property as a string; however in some cases (such as `checked=={{todo.checked}}` it can be resolved as a boolean value).
+In this example, this template is rendered with an object with key `todo` as data context (we'll see below how to enforce that). We access the properties of the `todo`  using the mustache tag, such as `{{todo.text}}`. The default behaviour is to render that property as a string; however in some cases (such as `checked=={{todo.checked}}` it can be resolved as a boolean value).
 
 Note that simple string interpolations like this will always escape any HTML for you---so you don't need to perform safety checks for XSS.
 
-Additionally we can see an example of a *template helper*---`{{checkedClass}}` calls out to the `checkedClass` helper defined in a separate JavaScript file on the `todosItem` template:
+Additionally we can see an example of a *template helper*---`{{checkedClass}}` calls out to the `checkedClass` helper defined in a separate JavaScript file, which combined with the template defines the `todosItem` component:
 
 ```js
 Template.todosItem.helpers({
@@ -49,7 +49,7 @@ Template.todosItem.helpers({
 });
 ```
 
-In the context of a template helper, `this` is scoped to the current current *data context* at the point the helper was used. This can be hard to reason about, so it's often a good idea to instead pass the required data into the helper as an argument.
+In the context of a Blaze helper, `this` is scoped to the current current *data context* at the point the helper was used. This can be hard to reason about, so it's often a good idea to instead pass the required data into the helper as an argument.
 
 Apart from simple interpolation, mustache tags can control flow of the template. For instance, in the `listsShow` template, we render a list of todos via:
 
@@ -67,7 +67,7 @@ Apart from simple interpolation, mustache tags can control flow of the template.
 This snippet illustrates a few things:
 
  - The `{{#each in}}` block helper which renders a block one per element in an array or cursor, or an `{{else}}` block if no items exist.
- - Template inclusion `{{> todosItem (todoArgs todo)}}` which renders the `todosItem` template with a set data context, based on the output of the `todosArg` helper.
+ - Template inclusion `{{> todosItem (todoArgs todo)}}` which renders the `todosItem` component with a set data context, based on the output of the `todosArg` helper.
 
 You can read about the full Spacebars syntax [here](https://github.com/meteor/meteor/blob/devel/packages/spacebars/README.md), but in this section we'll attempt to cover some important finer details.
 
@@ -101,14 +101,14 @@ You can also pass the output of a helper to a template inclusion or other helper
 Here the `todo` is passed as argument to the `todoArgs` helper, then the output is passed into the `todosItem` template.
 
 <h3 id="inclusion">Template inclusion</h3>
-You "include" a subtemplate with the `{{>` syntax. By default, the sub-template will gain the data context of the caller, although it's usually a good idea to be explicit. You can provide a single object as argument (as we did with the object returned by the `todoArgs` helper above), or provide a list of keyword arguments, as the `listShowPage` template does:
+You "include" a sub-component with the `{{>` syntax. By default, the sub-component will gain the data context of the caller, although it's usually a good idea to be explicit. You can provide a single object as argument (as we did with the object returned by the `todoArgs` helper above), or provide a list of keyword arguments, as the `listShowPage` template does:
 
 ```html
 {{> listsShow todosReady=Template.subscriptionsReady
   list=(getFullList listIdOnly) todos=listIdOnly.todos}}
 ```
 
-In this case, the `listShow` template can expect a data context of the form:
+In this case, the `listShow` component can expect a data context of the form:
 
 ```js
 {
@@ -125,8 +125,6 @@ We saw above that using a helper (or data context lookup) in the form `checked={
 <a {{attributes}}>My Link</a>
 ```
 
-// XXX: can we find an example of this in Todos?
-
 ```js
 Template.foo.helpers({
   attributes() {
@@ -139,7 +137,7 @@ Template.foo.helpers({
 ```
 
 <h3 id="rendering-html">Rendering pure HTML</h3>
-Although by default a mustache tag won't render any HTML, for XSS security reasons, you can render pure HTML with the triple-mustache: `{{{`.
+Although by default a mustache tag won't render any HTML, for [XSS](https://en.wikipedia.org/wiki/Cross-site_scripting) security reasons, you can render pure HTML with the triple-mustache: `{{{`.
 
 ```html
 {{{myHtml}}}
@@ -156,7 +154,7 @@ Template.foo.helpers({
 You should be extremely careful about doing this, and always ensure you aren't returning user-generated content (or escape it if you do!) from such a helper.
 
 <h3 id="block-helpers">Block Helpers</h3>
-A block helper, called with `{{#` is a helper that takes (and may render) a block of Spacebars. For instance, we saw the `{{#each in}}` helper above which repeats a given block of Spacebars once per item in a list. You can also render a *template* as a block helper, rendering it's content via the `Template.contentBlock` and `Template.elseBlock`. For instance, you could create your own `{{#if}}` helper with:
+A block helper, called with `{{#` is a helper that takes (and may render) a block of Spacebars. For instance, we saw the `{{#each in}}` helper above which repeats a given block of Spacebars once per item in a list. You can also render a *component* as a block helper, rendering it's content via the `Template.contentBlock` and `Template.elseBlock`. For instance, you could create your own `{{#if}}` helper with:
 
 ```html
 <template name="myIf">
@@ -179,7 +177,7 @@ There are a few builtin block helpers that are worth knowing about:
 
 <h4 id="if-unless">If / Unless</h4>
 
-The `{{#if}}` and `{{#unless}}` helpers are fairly straightforward but invaluable for controlling the content generated by a template. Both operate by evaluating and checking their single argument for "falsey"-ness (in JS this means `null`, `undefined`, `0`, `''`, `[]` and of course `false`).
+The `{{#if}}` and `{{#unless}}` helpers are fairly straightforward but invaluable for controlling the control flow of a template. Both operate by evaluating and checking their single argument for "falsey"-ness (in JS this means `null`, `undefined`, `0`, `''`, `[]` and of course `false`).
 
 ```html
 {{#if something}}
@@ -251,10 +249,10 @@ We use an `autorun()` here to ensure that the data context is validated again wh
 <h3 id="name-data-contexts">Name data contexts to template inclusions</h3>
 It's tempting to provide the data context of a sub-template as a "raw" object (like `{{> todosItem todo}}`), it's a better idea to explicitly give it a name (`{{> todosItem todo=todo}}`). There are two primary reasons for this:
 
-1. When using the data in the sub-template, it's a lot clearer what you are accessing `{{todo.title}}` is clearer than `title`.
+1. When using the data in the sub-component, it's a lot clearer what you are accessing `{{todo.title}}` is clearer than `title`.
 2. It's more flexible, in case in future you need to provide more arguments to the template.
 
-  For instance, in the case of the `todosItem` sub-template, we need to provide two extra arguments to control the editing state of the item, which would have been a hassle to add if the item was used with a raw `todo` argument.
+  For instance, in the case of the `todosItem` sub-component, we need to provide two extra arguments to control the editing state of the item, which would have been a hassle to add if the item was used with a raw `todo` argument.
 
 Additionally, for similar reasons of clarity, always explicitly provide a data context to an inclusion, rather than letting it passively "fall-through".
 
@@ -264,7 +262,7 @@ For similar reasons to the above, it's better to use `{{#each todo in todos}}` r
 The only reason not to use `{{#each .. in}}` because it makes it difficult to access the `todo` symbol inside event handlers. Typically the solution to this is simply to use a sub-component to render the inside of the loop.
 
 <h3 id="use-template-instance">Use the template instance</h3>
-Although Blaze's simple API doesn't naturally lead to a componentized approach, you can use the *template instance* as a convenient place to modularize functionality. The template instance is `this` inside template lifecycle callbacks and can be accessed in event handlers and helpers as `Template.instance()`. It's also passed as second argument to event handlers.
+Although Blaze's simple API doesn't naturally lead to a componentized approach, you can use the *template instance* as a convenient place to modularize functionality. The template instance is `this` inside Blaze's lifecycle callbacks and can be accessed in event handlers and helpers as `Template.instance()`. It's also passed as second argument to event handlers.
 
 We suggest a convention of naming it `instance` in these contexts and assigning it at the top of every relevant helper. For instance:
 
@@ -316,7 +314,7 @@ Template.listsShow.onCreated(function() {
       listId: this.data.list._id,
       newName: this.$('[name=name]').val()
     }, (err) => {
-      err && alert(err.error); // XXX i18n
+      err && alert(err.error);
     });
   };
 });
@@ -350,7 +348,7 @@ Template.listsShow.events({
 When you are setting up event maps in your JS files, you need to 'select' the element in the template that the event attaches to. Rather than using the same CSS classnames that are used to style the elements, it's better practice to use classnames that are specifically added for those event maps. A reasonable convention is a class starting with `js-` to indicate it is used by the JavaScript. For instance `.js-todo-add` above.
 
 <h3 id="passing-template-content">Passing HTML content as template arguments</h3>
-If you need to pass in content to a sub-template (for instance the content of a modal dialog), you can use the [custom block helper](#block-helpers) to provide a block of content. If you need more flexibility, typically just providing a named template a data context is the way to go. The sub-template can then just render that template with
+If you need to pass in content to a sub-component (for instance the content of a modal dialog), you can use the [custom block helper](#block-helpers) to provide a block of content. If you need more flexibility, typically just providing a named component in the data context is the way to go. The sub-component can then just render that component with:
 
 ```html
 {{> Template.dynamic templateName dataContext}}
@@ -359,9 +357,9 @@ If you need to pass in content to a sub-template (for instance the content of a 
 This is more or less the way that the [`kadira:blaze-layout`](https://atmospherejs.com/kadira/blaze-layout) package works in practice.
 
 <h3 id="pass-callbacks">Pass callbacks</h3>
-If you need to communicate *up* the template hierarchy, it's best to pass a *callback* for the subtemplate to call.
+If you need to communicate *up* the component hierarchy, it's best to pass a *callback* for the sub-component to call.
 
-For instance, only one todo item can be currently in the editing state at a time, so the `listsShow` template manages the state of which is edited. So when you focus on an item, that item needs to tell the list's template to make it the "edited" one. To do that, we pass a callback into the `todosItem` template, and it calls it:
+For instance, only one todo item can be currently in the editing state at a time, so the `listsShow` component manages the state of which is edited. So when you focus on an item, that item needs to tell the list's component to make it the "edited" one. To do that, we pass a callback into the `todosItem` component, and it calls it:
 
 ```html
 {{> todosItem (todoArgs todo)}}
@@ -389,9 +387,9 @@ Template.todosItem.events({
 ```
 
 <h3 id="onrendered-for-libs">Use `onRendered()` to callout to 3rd party libraries</h3>
-As we mentioned above, the `onRendered()` callback is typically the right spot to call out to third party libraries that expect a pre-rendered DOM (such as jQuery plugins). The `onRendered()` callback is triggered *once* after the template is rendered and attached to the DOM for the first time.
+As we mentioned above, the `onRendered()` callback is typically the right spot to call out to third party libraries that expect a pre-rendered DOM (such as jQuery plugins). The `onRendered()` callback is triggered *once* after the component has rendered and attached to the DOM for the first time.
 
-Occasionally, you may need to wait for data to become ready before it's time to attach the plugin (although typically it's a better idea to use a sub-template in this use case). To do so, you can setup an `autorun` in the `onRendered()` callback. For instance, in the `listShowPage` template, we want to wait until the subscription for the list is ready (i.e. the todos have rendered) before we hide the launch screen:
+Occasionally, you may need to wait for data to become ready before it's time to attach the plugin (although typically it's a better idea to use a sub-component in this use case). To do so, you can setup an `autorun` in the `onRendered()` callback. For instance, in the `listShowPage` template, we want to wait until the subscription for the list is ready (i.e. the todos have rendered) before we hide the launch screen:
 
 ```
 Template.listsShowPage.onRendered(function() {
@@ -405,7 +403,7 @@ Template.listsShowPage.onRendered(function() {
 ```
 
 <h2 id="smart-components">Writing smart components with Blaze</h2>
-If your component needs to access state outside of its data context---for instance, data from the server via subscriptions or the the contents of client-side store, then you should be careful how you do that accessing. As discussed in the [data loading](data-loading) and [UI](ui-ux#smart-components) articles you should be careful and considered in how use such smart components.
+If your component needs to access state outside of its data context---for instance, data from the server via subscriptions or the the contents of client-side store, then you should be careful how you do that accessing. As discussed in the [data loading](data-loading) and [UI](ui-ux#smart-components) articles, you should be careful and considered in how use such smart components.
 
 To begin with, all of the rules of thumb about reusable components apply to smart components. In addition:
 
@@ -424,7 +422,7 @@ Template.listsShowPage.onCreated(function() {
 
 By using `this.subscribe()` (as opposed to `Meteor.subscribe`), the subscription state automatically gets amalagamated into the template instance's subscription readiness reactive state variable, which can be used both from within templates (via the `{{Template.subscriptionsReady}}` helper) or within helpers (via `instance.subscriptionsReady()`).
 
-Notice as well in this case that we access the global client-side state store `FlowRouter` in this template, which we access via a instance method (`getListId()`), called both from the autorun, and from the `listArray` helper:
+Notice as well in this case that we access the global client-side state store `FlowRouter` in this component, which we access via a instance method (`getListId()`), called both from the autorun, and from the `listArray` helper:
 
 ```js
 Template.listsShowPage.helpers({
@@ -460,7 +458,6 @@ It's usually best to keep your view layer as "skinny" as possible and contain a 
 For instance, if a component requires a lot of complicated [D3](d3js.org) code for drawing graphs, it's likely that that code itself could live in a utility library that's called by the component. That makes it easier to abstract the code later and share it between various components that need to all draw graphs.
 
 <h3 id="global-helpers">Global Helpers</h3>
-
 One type of library that is useful is a global Spacebars helper. You can define these with the `Template.registerHelper()` function. Typically you register helpers to do simple things (like rendering dates in a given format) which don't justify a separate sub-component. For instance, you could do:
 
 ```js
@@ -482,11 +479,11 @@ Template.registerHelper('shortDate', (date) => {
 Although Blaze is a very intuitive rendering system, it does have some quirks and complexities that are worth knowing about when you are trying to do complex things.
 
 <h3 id="re-rendering">Re-rendering</h3>
-Blaze is intended to be opaque about re-rendering. Tracker and Blaze are designed as "eventual" systems that end up fully reflecting any data change, but may take a few steps in getting there, depending on how they are used. This can be the subject of frustration if you are trying to control how your template is re-rendered.
+Blaze is intended to be opaque about re-rendering. Tracker and Blaze are designed as "eventual" systems that end up fully reflecting any data change, but may take a few steps in getting there, depending on how they are used. This can be the subject of frustration if you are trying to control how your component is re-rendered.
 
-The first thing to consider here is if you actually need to care about your template re-rendering. Blaze is optimized so that it typically doesn't matter if a template is re-rendered even if it strictly shouldn't. If you make sure that your helpers are cheap to run and consequently rendering is not expensive, then you probably don't need to worry about this.
+The first thing to consider here is if you actually need to care about your component re-rendering. Blaze is optimized so that it typically doesn't matter if a component is re-rendered even if it strictly shouldn't. If you make sure that your helpers are cheap to run and consequently rendering is not expensive, then you probably don't need to worry about this.
 
-The main thing to understand about how Blaze re-renders is that re-rendering happens at the level of helpers and template inclusions. Whenever the *data context* of a template changes, it necessarily must re-run *all* helpers and data accessors (as `this` within the helper is the data context and thus will have changed). 
+The main thing to understand about how Blaze re-renders is that re-rendering happens at the level of helpers and template inclusions. Whenever the *data context* of a component changes, it necessarily must re-run *all* helpers and data accessors (as `this` within the helper is the data context and thus will have changed). 
 
 Additionally, helpers will re-run if any *reactive variable* accessed from within *that specific helper* changes.
 
@@ -503,7 +500,7 @@ Template.myTemplate.helpers({
 ```
 
 <h3 id="controlling-re-rendering">Controlling re-rendering</h3>
-If your helper or subtemplate is expensive to run, and often re-runs without any visible effect, you can short circuit unnecessary re-runs by using a more subtle reactive data source. A good candidate is provided by the [`peerlibrary:computed-field`](https://atmospherejs.com/peerlibrary/computed-field) library.
+If your helper or sub-component is expensive to run, and often re-runs without any visible effect, you can short circuit unnecessary re-runs by using a more subtle reactive data source. A good candidate is provided by the [`peerlibrary:computed-field`](https://atmospherejs.com/peerlibrary/computed-field) library.
 
 <h3 id="attribute-helpers">Attribute helpers</h3>
 Setting tag attributes via helpers (e.g. `<div {{attributes}}>`) is a neat tool and has some precedence rules that make it more useful. Specifically, when you use it more than once on a given element, the attributes are composed (rather than the second set of attributes simply replacing the first). So you can use one helper to set one set of attributes and a second to set another. For instance:
@@ -531,16 +528,16 @@ Template.myTemplate.helpers({
 <h3 id="lookups">Lookup order</h3>
 Another complicated topic in Blaze is name lookups. In what order does Blaze look when you write `{{something}}`? It runs in the following order:
 
-1. Helper defined on the current template.
+1. Helper defined on the current component.
 2. Binding (eg. from `{{#let}}` or `{{#each in}}`) in current scope
 3. A named template
 4. Global helpers
 5. The current data context.
 
 <h3 id="build-system">Blaze and the build system</h3>
-As mentioned in the [build system article](build-tool#blaze), the [`blaze-html-templates`](https://atmospherejs.com/meteor/blaze-html-templates) package scans your source code for `.html` files, picks out `<template name="templateName">` tags, and compiles them into a JavaScript file that defines a function that implements the template in code, attached to the `Template.templateName` symbol.
+As mentioned in the [build system article](build-tool#blaze), the [`blaze-html-templates`](https://atmospherejs.com/meteor/blaze-html-templates) package scans your source code for `.html` files, picks out `<template name="templateName">` tags, and compiles them into a JavaScript file that defines a function that implements the component in code, attached to the `Template.templateName` symbol.
 
-This means when you include another template, you are simply running a function on the client that corresponds to the Spacebars content you defined in the `.html` file.
+This means when you include another component, you are simply running a function on the client that corresponds to the Spacebars content you defined in the `.html` file.
 
 <h3 id="views">What is a view</h3>
 Blaze has an additional concept called a "view", which is associated with a reactively rendering area of a template. The view is the machinery that works behind the scenes to track reactivity, do lookups, and re-render appropriately when data changes. The view is the unit of re-rendering in Blaze. You can if necessary, use the view to walk the rendered component heirarchy, although, except in advanced cases it's better to not do this, but instead use callbacks and template arguments, or global data stores to communicate between components.

--- a/content/blaze.md
+++ b/content/blaze.md
@@ -237,11 +237,13 @@ You can do this in the components `onCreated()` callback, like so:
 ```js
 Template.listsShow.onCreated(function() {
   this.autorun(() => {
-    check(Template.data(), new SimpleSchema({
-     list: {blackbox: true},
-     todosReady: {type: Boolean}
-   }));
+    new SimpleSchema({
+      list: {type: Lists._helpers},
+      todosReady: {type: Boolean},
+      todos: {type: Mongo.Cursor}
+    }).validate(Template.currentData());
   });
+});
 ```
 
 We use an `autorun()` here to ensure that the data context is validated again whenever it changes.

--- a/content/blaze.md
+++ b/content/blaze.md
@@ -66,7 +66,7 @@ Apart from simple interpolation, mustache tags can control flow of the template.
 
 This snippet illustrates a few things:
 
- - The `{{#each in}}` block helper which renders a block one per element in an array or cursor, or an `{{else}}` block if no items exist.
+ - The `{{#each .. in}}` block helper which renders a block one per element in an array or cursor, or an `{{else}}` block if no items exist.
  - Template inclusion `{{> todosItem (todoArgs todo)}}` which renders the `todosItem` component with a set data context, based on the output of the `todosArg` helper.
 
 You can read about the full Spacebars syntax [here](https://github.com/meteor/meteor/blob/devel/packages/spacebars/README.md), but in this section we'll attempt to cover some important finer details.
@@ -91,6 +91,8 @@ Template.todosItem.helpers({
   }
 });
 ```
+
+Note that to get the keyword arguments, you need to read them off the `hash` property of the final argument to the helper. This is a little awkward, so in general it's usually easier not to use them.
 
 You can also pass the output of a helper to a template inclusion or other helper. To do so, use brackets to show precedence:
 
@@ -137,7 +139,7 @@ Template.foo.helpers({
 ```
 
 <h3 id="rendering-html">Rendering pure HTML</h3>
-Although by default a mustache tag won't render any HTML, for [XSS](https://en.wikipedia.org/wiki/Cross-site_scripting) security reasons, you can render pure HTML with the triple-mustache: `{{{`.
+Although by default a mustache tag will escape HTML tags to avoid [XSS](https://en.wikipedia.org/wiki/Cross-site_scripting),, you can render raw HTML with the triple-mustache: `{{{`.
 
 ```html
 {{{myHtml}}}
@@ -154,7 +156,7 @@ Template.foo.helpers({
 You should be extremely careful about doing this, and always ensure you aren't returning user-generated content (or escape it if you do!) from such a helper.
 
 <h3 id="block-helpers">Block Helpers</h3>
-A block helper, called with `{{#` is a helper that takes (and may render) a block of Spacebars. For instance, we saw the `{{#each in}}` helper above which repeats a given block of Spacebars once per item in a list. You can also render a *component* as a block helper, rendering it's content via the `Template.contentBlock` and `Template.elseBlock`. For instance, you could create your own `{{#if}}` helper with:
+A block helper, called with `{{#` is a helper that takes (and may render) a block of Spacebars. For instance, we saw the `{{#each .. in}}` helper above which repeats a given block of Spacebars once per item in a list. You can also render a *component* as a block helper, rendering it's content via the `Template.contentBlock` and `Template.elseBlock`. For instance, you could create your own `{{#if}}` helper with:
 
 ```html
 <template name="myIf">
@@ -189,14 +191,15 @@ The `{{#if}}` and `{{#unless}}` helpers are fairly straightforward but invaluabl
 
 <h4 id="each-in">Each-in</h4>
 
-The `{{#each in}}` helper is a convenient way to step over a list whilst retaining the outer data context. 
+The `{{#each .. in}}` helper is a convenient way to step over a list whilst retaining the outer data context. 
 
 ```html
 {{#each todo in todos}}
+  {{#each tag in todo.tags}}
+    <!-- in here, both todo and tag are in scope -->
+  {{/each}}
 {{/each}}
 ```
-
-In this case `todo` will be added to the template scope within the block, but all the existing data context items (`list` and `todosReady` in this case) will remain available.
 
 <h4 id="let">Let</h4>
 The `{{#let}}` helper is useful to capture the output of a helper or document subproperty within a template:
@@ -229,8 +232,6 @@ Examples below will reference the `listShow` component from the Todos example ap
 
 <h3 id="validate-data-context">Validate data contexts</h3>
 In order to ensure your component is only used in the way you expect, you should validate the data context provided to it. The data context provides the inputs to the component and so should be checked.
-
-XXX: this does not yet work
 
 You can do this in the components `onCreated()` callback, like so:
 

--- a/content/blaze.md
+++ b/content/blaze.md
@@ -275,8 +275,8 @@ Template.listsShow.helpers({
     return {
       todo,
       editing: instance.state.equals('editingTodo', todo._id),
-      onEdit(doEdit) {
-        instance.state.set('editingTodo', doEdit ? todo._id : false);
+      onEditingChange(editing) {
+        instance.state.set('editingTodo', editing ? todo._id : false);
       }
     };
   }
@@ -374,8 +374,8 @@ Template.listsShow.helpers({
     return {
       todo,
       editing: instance.state.equals('editingTodo', todo._id),
-      onEdit(doEdit) {
-        instance.state.set('editingTodo', doEdit ? todo._id : false);
+      onEditingChange(editing) {
+        instance.state.set('editingTodo', editing ? todo._id : false);
       }
     };
   }
@@ -383,7 +383,7 @@ Template.listsShow.helpers({
 
 Template.todosItem.events({
   'focus input[type=text]'() {
-    this.onEdit(true);
+    this.onEditing(true);
   }
 });
 ```

--- a/content/blaze.md
+++ b/content/blaze.md
@@ -546,6 +546,8 @@ Blaze has an additional concept called a "view", which is associated with a reac
 
 You can read more about views in the [Blaze docs](http://docs.meteor.com/#/full/blaze_view).
 
+<h2 id="testing">Testing Blaze templates</h2>
+XXX: Going to do this after testing chapter
 
 
 6. Testing Blaze templates
@@ -553,7 +555,3 @@ You can read more about views in the [Blaze docs](http://docs.meteor.com/#/full/
   2. Querying the DOM (general but just a pointer here)
   3. Triggering reactivity and waiting for re-rendering
   4. Simulating events w/ JQ
-7. Useful Blaze utilities / other approaches
-  1. https://github.com/peerlibrary/meteor-blaze-components
-  2. https://github.com/raix/Meteor-handlebar-helpers
-  3. Much, much more...

--- a/content/blaze.md
+++ b/content/blaze.md
@@ -1,0 +1,259 @@
+---
+title: Blaze
+---
+
+After reading this guide, you'll know:
+
+1. How to use the Spacebars syntax, used to define Blaze templates.
+2. Best practice towards creating reusable components in Blaze.
+3. How the Blaze rendering engine works under the hood and some techniques to best use it.
+4. How to test Blaze templates.
+
+Blaze is Meteor's built in reactive rendering library. Using templates written in [Spacebars](https://github.com/meteor/meteor/blob/devel/packages/spacebars/README.md), a variant of [Handlebars](http://handlebarsjs.com) designed to take advantage of [Tracker](https://github.com/meteor/meteor/tree/devel/packages/tracker), Meteor's reactivity system.
+
+Blaze is not required to built applications in Meteor---you can equally use [React](http://react-in-meteor.readthedocs.org/en/latest/) or [Angular](http://www.angular-meteor.com), however this guide will take you through best practice in building an application in Blaze.
+
+<a id="spacebars">Spacebars</a>
+
+Spacebars is a handlebars-like templating language, built off the concept of rendering a reactivily changing *data context*. Spacebars templates look like simple HTML with special "mustache" tags delimited by `{{` and `}}`.
+
+As an example, consider the `todosItem` template from the Todos example app:
+
+```html
+<template name="todosItem">
+  <div class="list-item {{checkedClass}} {{editingClass}}">
+    <label class="checkbox">
+      <input type="checkbox" checked={{todo.checked}} name="checked">
+      <span class="checkbox-custom"></span>
+    </label>
+
+    <input type="text" value="{{todo.text}}" placeholder="Task name">
+    <a class="js-delete-item delete-item" href="#">
+      <span class="icon-trash"></span>
+    </a>
+  </div>
+</template>
+```
+
+In this example, the template is rendered with an object with key `todo` as data context (we'll see below how to enforce that). We access the properties of the `todo`  using the mustache tag, such as `{{todo.text}}`. The default behaviour is to render that property as a string; however in some cases (such as `checked=={{todo.checked}}` it can be resolved as a boolean value).
+
+Note that simple string interpolations like this will never render HTML---so you don't need to perform safety checks for XSS.
+
+Additionally we can see an example of a *template helper*---`{{checkedClass}}` calls out to the `checkedClass` helper defined in a separate JavaScript file on the `todosItem` template:
+
+```js
+Template.todosItem.helpers({
+  checkedClass() {
+    return this.todo.checked && 'checked';
+  }
+});
+```
+
+In the context of a template helper, `this` is scoped to the the *data context* of the template.
+
+Apart from simple interpolation, mustache tags can control flow of the template. For instance, in the `listsShow` template, we render a list of todos via:
+
+```html
+  {{#each todo in todos}}
+    {{> todosItem (todoArgs todo)}}
+  {{else}}
+    <div class="wrapper-message">
+      <div class="title-message">No tasks here</div>
+      <div class="subtitle-message">Add new tasks using the field above</div>
+    </div>
+  {{/each}}
+```
+
+This snippet illustrates a few things:
+
+ - The `{{#each in}}` block helper which renders a block one per element in an array or cursor, or an `{{else}}` block if no items exist.
+ - Template inclusion `{{> todosItem (todoArgs todo)}}` which renders the `todosItem` template with a set data context, based on the output of the `todosArg` helper.
+
+You can read about the full Spacebars syntax [here](https://github.com/meteor/meteor/blob/devel/packages/spacebars/README.md), but in this section we'll attempt to cover some important finer details.
+
+<h3 id="data-contexts">Data contexts and lookup</h3>
+We've seen `{{todo.title}}` accesses the `title` property of the `todo` item on the current data context. Additionaly, `..` access the parent data context (rarely a good idea), `list.todos.[0]` accesses the first element of the `todos` array on `list`.
+
+Also, note that Spacebars is very forgiving of `null` values. It will not complain if you try to access a property on a `null` value (for instance `foo.bar` if `foo` is not defined), but instead simply treat it also as null. However there are exceptions to this---trying to call a `null` function, or doing the same *within* a helper will lead to exceptions.
+
+<h3 id="helpers">Calling helpers with arguments</h3>
+You can provide arguments to a helper like `checkedClass` by simply placing the argument after the helper call, as in: `{{checkedClass todo true 'checked'}}`. You can also provide a list of named keyword arguments to a helper with `{{checkedClass todo noClass=true classname='checked'}}. In this case, you might access those arguments with:
+
+```js
+Template.todosItem.helpers({
+  checkedClass(todo, kws) {
+    const classname = kws.hash.classname || 'checked';
+    if (todo.checked) {
+      return classname;
+    } else if (kws.hash.noClass) {
+      return `no-${classname}`;
+    }
+  }
+});
+```
+
+You can also pass the output of a helper to a template inclusion or other helper. To do so, use brackets to show precedence:
+
+```html
+{{> todosItem (todoArgs todo)}}
+```
+
+Here the `todo` is passed as argument to the `todoArgs` helper, then the output is passed into the `todosItem` template.
+
+<h3 id="inclusion">Template inclusion</h3>
+You "include" a subtemplate with the `{{>` syntax. By default, the sub-template will gain the data context of the caller, although it's usually a good idea to be explicit. You can provide a single object as argument (as we did with the object returned by the `todoArgs` helper above), or provide a list of keyword arguments, as the `listShowPage` template does:
+
+```html
+{{> listsShow todosReady=Template.subscriptionsReady
+  list=(getFullList listIdOnly) todos=listIdOnly.todos}}
+```
+
+In this case, the `listShow` template can expect a data context of the form:
+
+```js
+{
+  todosReady: ...,
+  list: ...,
+  todos: ...
+}
+```
+
+<h3 id="helpers-in-tags">Helpers in tags</h3>
+We saw above that using a helper (or data context lookup) in the form `checked={{todo.checked}}` will add the checked property to the HTML tag if `todo.checked` evaluates to true. Also, you can directly include an object as part of an HTML to apply multiple properties at once:
+
+```html
+<a {{attributes}}>My Link</a>
+```
+
+// XXX: can we find an example of this in Todos?
+
+```js
+Template.foo.helpers({
+  attributes: () => {
+    return {
+      class: 'A class',
+      style: {background: 'blue'}
+    };
+  }
+});
+```
+
+<h3 id="rendering-html">Rendering pure HTML</h3>
+Although by default a mustance tag won't render any HTML, for XSS security reasons, you can render pure HTML with the triple-mustache: `{{{`.
+
+```html
+{{{myHtml}}}
+```
+
+```js
+Template.foo.helpers({
+  myHtml() {
+    return '<h1>This H1 will render</h1>';
+  }
+});
+```
+
+You should be extremely careful about doing this, and always ensure you aren't returning user-generated content (or escape it if you do!) from such a helper.
+
+<h3 id="block-helpers">Block Helpers</h3>
+A block helper, called with `{{#` is a helper that takes (and may render) a block of Spacebars. For instance, we saw the `{{#each in}}` helper above which repeats a given block of Spacebars once per item in a list. You can also render a *template* as a block helper, rendering it's content via the `Template.contentBlock` and `Template.eachBlock`. For instance, you could create your own `{{#if}}` helper with:
+
+```html
+<template name="myIf">
+  {{#if condition}}
+    {{> Template.contentBlock}}
+  {{else}}
+    {{> Template.elseBlock}}
+  {{/if}}
+</template>
+
+<template name="caller">
+  {{#myIf condition=true}}
+    <h1>I'll be rendered!</h1>
+  {{/myIf}}
+```
+
+<h3 id="builtin-block-helpers">Builtin Block Helpers</h3>
+There are a few builtin block helpers that are worth knowing about:
+
+<h4 id="if-unless">If / Unless</h4>
+
+The `{{#if}}` and `{{#unless}}` helpers are fairly straightforward but invaluable for controlling the content generated by a template. Both operate by evaluating and checking their single argument for "falsey"-ness (in JS this means `null`, `undefined`, `0`, `''`, `[]` and of course `false`).
+
+```html
+{{#if something}}
+  <p>It's true</p>
+{{else}}
+  <p>It's false</p>
+{{/if}}
+```
+
+<h4 id="each-in">Each-in</h4>
+
+The `{{#each in}}` helper is a convenient way to step over a list whilst retaining the outer data context. 
+
+```html
+{{#each todo in todos}}
+{{/each}}
+```
+
+In this case `todo` will be added to the data context within the block, but all the existing data context items (`list` and `todosReady` in this case) will remain available.
+
+<h4 id="let">Let</h4>
+The `{{#let}}` helper is useful to capture the output of a helper or document subproperty within a template:
+
+```html
+{{#let name=person.bio.firstName color=generateColor}}
+  <div>{{name}} gets a {{color}} card!</div>
+{{/let}}
+```
+
+XXX: what to do about d.c. changing helpers such as with/each?
+
+<h4 id="strictness">Strictness</h4>
+Spacebars starts from a very strict interpretation of HTML. In particular you need to careful about self-closing tags and when you are allowed to use them. For instance, you can't self-close a `div` (`<div/>`) in Spacebars.
+
+<h4 id="escaping">Escaping</h4>
+To insert a literal {{, {{{, or any number of curly braces, put a vertical bar after it. So `{{|` will show up as `{{`, `{{{|` will show up as `{{{`, and so on.
+
+
+2. Creating reusable "pure" components with Blaze / best practice (a lot of this is repeating @sanjo's boilerplate)
+  1. Validating data context fits a schema
+  2. Always set data contexts to `{name: doc}` rather than just `doc`. Always set a d.c on an inclusion.
+  3. Use `{{#each .. in .. }}` to achieve the above
+  4. Use the template instance as a component -- adding a `{{instance}}` helper to access it
+  5. Use a (named / scoped on `_id` if possible) reactive dict for instance state
+  6. Attach functions to the template instance (in `onCreated`) to sensibly modify state
+  7. Place `const instance = Template.instance()` at the top of all helpers/event handlers that care about state
+  8. Always scope DOM lookups with `this.$`
+  9. Use `.js-X` in event maps
+  10. Pass extra content to components with `Template.contentBlock`, or named template arguments
+  11. Use the `onRendered` callback to integrate w/ 3rd party libraries
+    1. Waiting on subscriptions w/ `autorun` pattern: https://github.com/meteor/guide/pull/75/files#r43545240
+3. Writing "smart" components with Blaze
+  1. All of section 2.
+  2. Use `this.autorun` and `this.subscribe`, listening to `FlowRouter` and `this.state`
+  3. Set up cursors in helpers to be passed into pure sub-components, and filtered with `cursor-utils`
+    1. Why cursors are preferred to arrays.
+  4. Access stores directly from helpers.
+4. Reusing code between templates
+  1. Prefer utilities/composition to mixins or inheritance
+  2. How to write global helpers
+5. Understanding Blaze
+  1. When does a template re-render (when its data context changes)
+  2. When does a helper-rerun? (when its data context or reactive deps change)
+    1. So be careful, this can happen a lot! If your helper is expensive, consider something like https://github.com/peerlibrary/meteor-computed-field
+  3. How does an each tag re-run / decide when new data should appear?
+    1. How does the `{{attrs}` syntax work, some tricks on how to use it.
+  4. How do name lookups work?
+  5. What does the build system do exactly?
+  6. What is a view?
+6. Testing Blaze templates
+  1. Rendering a template in a unit test
+  2. Querying the DOM (general but just a pointer here)
+  3. Triggering reactivity and waiting for re-rendering
+  4. Simulating events w/ JQ
+7. Useful Blaze utilities / other approaches
+  1. https://github.com/peerlibrary/meteor-blaze-components
+  2. https://github.com/raix/Meteor-handlebar-helpers
+  3. Much, much more...

--- a/content/blaze.md
+++ b/content/blaze.md
@@ -246,7 +246,7 @@ Template.listsShow.onCreated(function() {
   });
 ```
 
-By placing the validation in an `autorun()` we ensure that even if the data contexts reactively changes, it always fits the expected schema.
+We use an `autorun()` here to ensure that the data context is validated again whenever it changes.
 
 <h3 id="name-data-contexts">Name data contexts to template inclusions</h3>
 It's tempting to provide the data context of a sub-template as a "raw" object (like `{{> todosItem todo}}`), it's a better idea to explicitly give it a name (`{{> todosItem todo=todo}}`). There are two primary reasons for this:


### PR DESCRIPTION
This is done, barring testing, which I'll do post-testing article
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/meteor/guide/pull/139%23discussion_r46922770%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r46922856%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r46923841%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r46923962%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r46923988%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r46924033%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r46924063%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r46924114%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r46924129%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r46924201%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r46924228%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r46924273%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r46924305%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r46924409%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r46924466%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r46924524%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r46924580%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r46924665%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r46924901%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47039618%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47039661%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47040756%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47040867%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47040883%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47040909%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47040922%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47040937%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47040972%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47041931%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47041959%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47041971%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47041983%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47041987%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47042035%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47042088%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47042150%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47042193%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47042317%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47042330%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47042496%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47042585%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47042669%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47042740%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47042789%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47042804%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47042848%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47042940%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47042953%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47042992%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47043018%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47043127%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47043235%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47043248%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47043251%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47043269%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47043288%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47043320%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47043400%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47043445%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47044579%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47044656%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47044664%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47044978%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47045142%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47045188%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47045190%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47045231%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47045382%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47045424%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47045425%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47046610%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47051770%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47051780%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47052043%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47053104%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47056279%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47056363%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47056438%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47056531%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47056579%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47056605%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47320210%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47320251%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47320278%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47320326%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47320383%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47321104%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47390797%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47390882%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47390950%22%2C%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47391208%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%20b9291f572b55c3a2226763991b8268d67efd7384%20content/blaze.md%20159%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r46924063%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60eachBlock%60%20-%3E%20%60elseBlock%60%22%2C%20%22created_at%22%3A%20%222015-12-08T08%3A03%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-09T01%3A22%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20content/blaze.md%3AL1-544%22%7D%2C%20%22Pull%20b9291f572b55c3a2226763991b8268d67efd7384%20content/blaze.md%20243%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r46924466%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20sentence%20is%20janky%22%2C%20%22created_at%22%3A%20%222015-12-08T08%3A08%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hmm%2C%20what%20would%20you%20say%20instead%3F%22%2C%20%22created_at%22%3A%20%222015-12-09T01%3A41%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-12-09T02%3A38%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20content/blaze.md%3AL1-544%22%7D%2C%20%22Pull%20b9291f572b55c3a2226763991b8268d67efd7384%20content/blaze.md%20261%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r46924580%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%5C%22Although%20Blaze%20doesn%27t%20currently%20have%20a%20fully%20baked%20component%20model%5C%22%20is%20overly%20negative%20IMO.%20Plus%20I%20bet%20certain%20people%20would%20disagree%20with%20this%20statement.%22%2C%20%22created_at%22%3A%20%222015-12-08T08%3A10%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22Better%3F%22%2C%20%22created_at%22%3A%20%222015-12-09T01%3A49%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-12-09T02%3A33%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20content/blaze.md%3AL1-544%22%7D%2C%20%22Pull%20b9291f572b55c3a2226763991b8268d67efd7384%20content/blaze.md%20438%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47042669%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%27m%20not%20sure%20what%20this%20is%20recommending%20-%20should%20the%20functionality%20be%20factored%20out%20into%20a%20wrapper%20component%3F%22%2C%20%22created_at%22%3A%20%222015-12-09T01%3A48%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22Oh%2C%20I%20guess%20I%20was%20thinking%20of%20composition%2C%20if%20you%20can%20figure%20out%20a%20way%20to%20make%20it%20a%20child%20component.%20A%20wrapper%20component%20is%20sort%20of%20like%20complex%20composition%2C%20works%20too..%22%2C%20%22created_at%22%3A%20%222015-12-09T02%3A00%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20should%20probably%20think%20of%20an%20example%20here%20and%20demo%20it.%20Any%20ideas%3F%22%2C%20%22created_at%22%3A%20%222015-12-09T02%3A01%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20guess%20a%20common%20thing%20can%20be%20having%20some%20complex%20state%20or%20event%20handler%20logic.%20For%20example%2C%20you%20want%20to%20do%20auto-completing%20user%20search%2C%20and%20you%20want%20this%20to%20work%20inside%20a%20text%20area%20to%20tag%20users%2C%20or%20in%20a%20user%20selector%20somewhere.%22%2C%20%22created_at%22%3A%20%222015-12-09T02%3A32%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hrmm%2C%20need%20a%20better%20example%20for%20composition.%20Something%20not%20immediately%20obvious%20where%20you%20would%20pull%20out%20a%20sub-component%20if%20you%20wanted%20to%20share%20functionality.%5Cr%5Cn%5Cr%5CnI%20think%20this%20example%20doesn%27t%20really%20work%20as%20a%20subcomponent%20--%20what%20would%20the%20component%20render%3F%22%2C%20%22created_at%22%3A%20%222015-12-09T05%3A11%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20feel%20like%20we%20just%20need%20to%20go%20look%20at%20examples%20where%20people%20want%20to%20use%20template-extension%20or%20blaze%20components%20and%20talk%20about%20how%20to%20do%20them%20with%20composition.%22%2C%20%22created_at%22%3A%20%222015-12-09T06%3A52%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20added%20something.%20It%27s%20pretty%20crappy%20though.%22%2C%20%22created_at%22%3A%20%222015-12-11T04%3A34%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22It%20doesn%27t%20look%20like%20you%20pushed%20this%20change.%20After%20this%20we%20can%20merge%21%20Thanks%20for%20doing%20this%20article%2C%20must%20have%20been%20a%20slog%22%2C%20%22created_at%22%3A%20%222015-12-11T19%3A04%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20content/blaze.md%3AL1-544%22%7D%2C%20%22Pull%20b9291f572b55c3a2226763991b8268d67efd7384%20content/blaze.md%2052%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r46923841%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Data%20context%20of%20the%20element%20where%20the%20helper%20was%20used%2C%20not%20the%20template.%22%2C%20%22created_at%22%3A%20%222015-12-08T08%3A00%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22Also%2C%20I%20feel%20like%20we%20should%20discourage%20using%20%60this%60%20inside%20helpers%20in%20favor%20of%20passing%20arguments%20or%20using%20%60Template.instance%28%29.data%60%22%2C%20%22created_at%22%3A%20%222015-12-08T08%3A05%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22What%20do%20you%20think%20now%3F%22%2C%20%22created_at%22%3A%20%222015-12-09T01%3A20%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20don%27t%20think%20you%20pushed%20your%20change%20yet.%22%2C%20%22created_at%22%3A%20%222015-12-09T01%3A39%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yeah%20I%20write%20the%20comments%20as%20I%20go%20through%20the%20file%20and%20then%20push%20at%20the%20end%2C%20sorry.%20Pushed%20now.%22%2C%20%22created_at%22%3A%20%222015-12-09T01%3A52%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-12-09T02%3A33%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20content/blaze.md%3AL1-544%22%7D%2C%20%22Pull%20315ccaca1f3a767c75da9e70dc6d8a57393b49af%20content/blaze.md%20140%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47056531%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%5C%22won%27t%20render%20any%20HTML%5C%22%20-%3E%20%5C%22will%20escape%20HTML%20tags%20to%20avoid%20XSS%5C%22%5Cr%5Cn%5Cr%5Cn%5C%22you%20can%20render%20pure%20HTML%5C%22%20-%3E%20%5C%22you%20can%20render%20raw%20HTML%5C%22%22%2C%20%22created_at%22%3A%20%222015-12-09T06%3A58%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222015-12-11T04%3A09%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20content/blaze.md%3AL1-560%22%7D%2C%20%22Pull%201cc46ddc6efbc431ff7243bb3a73a28c36863b20%20content/blaze.md%20249%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47045382%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22We%20use%20an%20%60autorun%28%29%60%20to%20make%20sure%20that%20the%20data%20context%20is%20validated%20again%20whenever%20it%20changes.%22%2C%20%22created_at%22%3A%20%222015-12-09T02%3A37%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222015-12-09T03%3A05%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20content/blaze.md%3AL1-561%22%7D%2C%20%22Pull%20b9291f572b55c3a2226763991b8268d67efd7384%20content/blaze.md%207%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r46922770%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hmm%2C%20technically%20they%20are%20Spacebars%20templates%2C%20Blaze%20is%20just%20the%20underlying%20rendering%20engine...%20what%20do%20you%20think%3F%20Too%20pedantic%3F%20People%20use%20the%20word%20%5C%22Blaze%5C%22%20to%20refer%20to%20the%20whole%20thing%20these%20days.%22%2C%20%22created_at%22%3A%20%222015-12-08T07%3A41%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222015-12-09T01%3A06%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20content/blaze.md%3AL1-544%22%7D%2C%20%22Pull%20b9291f572b55c3a2226763991b8268d67efd7384%20content/blaze.md%20239%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r46924409%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60%60%60js%5Cr%5Cnnew%20SimpleSchema%28%7B%5Cr%5Cn%20%20list%3A%20%7Bblackbox%3A%20true%7D%2C%5Cr%5Cn%20%20todosReady%3A%20%7Btype%3A%20Boolean%7D%5Cr%5Cn%7D%29.validate%28Template.data%28%29%29%3B%5Cr%5Cn%60%60%60%5Cr%5Cn%5Cr%5CnThis%20works%20fine%2C%20we%20don%27t%20need%20to%20call%20%60check%60.%22%2C%20%22created_at%22%3A%20%222015-12-08T08%3A07%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yeah.%20We%20just%20need%20to%20make%20sure%20it%20actually%20works%20%28right%20now%20it%20throws%20due%20to%20the%20%60list%60%20failing%20the%20object%20test%29%22%2C%20%22created_at%22%3A%20%222015-12-09T01%3A40%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222015-12-09T05%3A36%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20content/blaze.md%3AL1-544%22%7D%2C%20%22Pull%20b9291f572b55c3a2226763991b8268d67efd7384%20content/blaze.md%20122%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r46923962%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%5C%22include%20an%20object%20as%20part%20of%20an%20HTML%20to%20apply%20multiple%20properties%20at%20once%3A%5C%22%20-%3E%20%5C%22Include%20an%20object%20in%20the%20attribute%20list%20of%20an%20HTML%20element%20to%20set%20multiple%20attributes%20at%20once.%5C%22%22%2C%20%22created_at%22%3A%20%222015-12-08T08%3A02%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-09T01%3A22%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20content/blaze.md%3AL1-544%22%7D%2C%20%22Pull%20b9291f572b55c3a2226763991b8268d67efd7384%20content/blaze.md%20214%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r46924305%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22You%20also%20need%20to%20close%20tags%20that%20don%27t%20need%20to%20be%20closed%20in%20HTML5%2C%20like%20%60%3Cp%3E%60.%22%2C%20%22created_at%22%3A%20%222015-12-08T08%3A06%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-09T01%3A38%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20content/blaze.md%3AL1-544%22%7D%2C%20%22Pull%20315ccaca1f3a767c75da9e70dc6d8a57393b49af%20content/blaze.md%2080%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47056438%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%27d%20specifically%20call%20out%20%60kws.hash%60%20in%20the%20text.%20It%27s%20a%20bit%20odd%20and%20deserves%20clarification.%20I%27d%20even%20go%20so%20far%20as%20to%20suggest%20avoiding%20keyword%20arguments%20to%20helpers%20for%20clarity%3F%22%2C%20%22created_at%22%3A%20%222015-12-09T06%3A56%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22Changed..%22%2C%20%22created_at%22%3A%20%222015-12-11T04%3A10%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222015-12-11T19%3A02%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20content/blaze.md%3AL1-560%22%7D%2C%20%22Pull%20b9291f572b55c3a2226763991b8268d67efd7384%20content/blaze.md%20272%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r46924665%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60doEdit%60%20is%20a%20super%20weird%20variable%20name.%20Not%20sure%20what%20it%20does.%20Maybe%20this%20is%20%60onFocusChange%60%20and%20%60focusStatus%60%20or%20%60onEditingStateChange%60%20and%20%60editingState%60%3F%20Or%20maybe%20even%20%60onFocus%60/%60onBlur%60.%22%2C%20%22created_at%22%3A%20%222015-12-08T08%3A11%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22How%20about%20just%20%60onEditingChange%60%20and%20%60editing%60%3F%22%2C%20%22created_at%22%3A%20%222015-12-09T01%3A50%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22Sounds%20good%21%22%2C%20%22created_at%22%3A%20%222015-12-09T01%3A58%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222015-12-09T02%3A22%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20content/blaze.md%3AL1-544%22%7D%2C%20%22Pull%20b9291f572b55c3a2226763991b8268d67efd7384%20content/blaze.md%20142%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r46924033%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22mustance%20-%3E%20mustache%22%2C%20%22created_at%22%3A%20%222015-12-08T08%3A03%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-09T01%3A22%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20content/blaze.md%3AL1-544%22%7D%2C%20%22Pull%20b9291f572b55c3a2226763991b8268d67efd7384%20content/blaze.md%20217%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r46924273%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Whoa%2C%20I%20had%20no%20idea...%20this%20would%20really%20simplify%20some%20stuff%20in%20the%20docs%20app%20lol%22%2C%20%22created_at%22%3A%20%222015-12-08T08%3A06%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22This%20is%20like%20basically%20copied%20out%20of%20the%20spacebars%20docs.%22%2C%20%22created_at%22%3A%20%222015-12-09T01%3A38%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-09T01%3A38%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20content/blaze.md%3AL1-544%22%7D%2C%20%22Pull%20b9291f572b55c3a2226763991b8268d67efd7384%20content/blaze.md%20258%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r46924524%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22sub-component%20-%3E%20sub-template%3F%20Not%20sure%20if%20we%20are%20using%20the%20word%20component%20to%20refer%20to%20Blaze%20entities%22%2C%20%22created_at%22%3A%20%222015-12-08T08%3A09%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20think%20I%27m%20pretty%20inconsistent%20in%20this%20article.%20I%27ve%20used%20component%20more%20or%20less%20everywhere%20else%20in%20the%20guide.%20It%27s%20hard%20to%20know%20what%20to%20use%20in%20this%20article%2C%20sometimes%20it%20seems%20like%20it%20should%20be%20component%20%28like%20when%20talking%20about%20%5C%22reusability%5C%22%29%2C%20other%20times%20template%20%28when%20talking%20about%20technicalities%20with%20Blaze%29.%20%20%5Cr%5Cn%5Cr%5CnThis%20is%20sort%20of%20in-between.%22%2C%20%22created_at%22%3A%20%222015-12-09T01%3A43%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22Switched%20to%20try%20and%20use%20component%20everywhere%20it%20makes%20any%20kind%20of%20sense.%5Cr%5Cn%5Cr%5CnIt%27s%20a%20bit%20wonky%20but%20probably%20the%20best%20of%20bad%20options.%22%2C%20%22created_at%22%3A%20%222015-12-09T05%3A02%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-09T05%3A02%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20content/blaze.md%3AL1-544%22%7D%2C%20%22Pull%20b9291f572b55c3a2226763991b8268d67efd7384%20content/blaze.md%20211%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r46924201%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%27d%20add%20a%20%5C%22historical%20note%5C%22.%5Cr%5Cn%5Cr%5CnAlso%2C%20is%20it%20confusing%20that%20you%20can%27t%20access%20%60name%60%20or%20%60color%60%20above%20from%20a%20helper%3F%22%2C%20%22created_at%22%3A%20%222015-12-08T08%3A05%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22Let%20me%20know%20what%20you%20think.%22%2C%20%22created_at%22%3A%20%222015-12-09T01%3A37%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222015-12-09T02%3A34%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20content/blaze.md%3AL1-544%22%7D%2C%20%22Pull%20b9291f572b55c3a2226763991b8268d67efd7384%20content/blaze.md%20420%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47042317%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22It%27s%20%60%7B%7BTemplate.subscriptionsReady%7D%7D%60%20inside%20Spacebars%2C%20and%20%60Template.instance%28%29.subscriptionsReady%28%29%60%20inside%20helpers.%22%2C%20%22created_at%22%3A%20%222015-12-09T01%3A42%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-09T01%3A54%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20content/blaze.md%3AL1-544%22%7D%2C%20%22Pull%20315ccaca1f3a767c75da9e70dc6d8a57393b49af%20content/blaze.md%20192%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47056579%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Should%20we%20add%20an%20example%20of%20a%20two-dimensional%20iteration%3F%20That%27s%20the%20main%20strength%20of%20%60each%20in%60%20over%20old%20%60each%60.%22%2C%20%22created_at%22%3A%20%222015-12-09T06%3A59%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22Is%20this%20better%3F%22%2C%20%22created_at%22%3A%20%222015-12-11T04%3A08%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222015-12-11T19%3A01%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20content/blaze.md%3AL1-560%22%7D%2C%20%22Pull%20b9291f572b55c3a2226763991b8268d67efd7384%20content/blaze.md%20424%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47042496%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20guess%20the%20logic%20is%2C%20we%20want%20to%20do%20all%20%5C%22smart%5C%22%20things%20inside%20%60onCreated%60%20rather%20than%20inside%20helpers%3F%20One%20more%20way%20to%20achieve%20that%20would%20be%20to%20define%20a%20function%20inside%20%60onCreated%60%20like%3A%5Cr%5Cn%5Cr%5Cn%60%60%60js%5Cr%5Cnthis.getListId%20%3D%20%28%29%20%3D%3E%20FlowRouter.getParam%28%27_id%27%29%5Cr%5Cn%5Cr%5Cnthis.autorun%28%28%29%20%3D%3E%20%7B%5Cr%5Cn%20%20this.subscribe%28%27list/todos%27%2C%20this.getListId%28%29%29%3B%5Cr%5Cn%7D%29%3B%5Cr%5Cn%60%60%60%5Cr%5Cn%5Cr%5CnAnd%20then%20use%20that%20function%20inside%20the%20helper.%20That%20way%20if%20you%20need%20to%20get%20the%20listId%20from%20somewhere%20else%2C%20you%20don%27t%20need%20to%20change%20the%20helper%3F%22%2C%20%22created_at%22%3A%20%222015-12-09T01%3A46%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22That%20seems%20like%20a%20very%20sensible%20approach%2C%20I%27ll%20make%20that%20change.%22%2C%20%22created_at%22%3A%20%222015-12-09T01%3A54%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22https%3A//github.com/meteor/todos/commit/eabfb2535a393476c870373b8eb105bf08d3d315%22%2C%20%22created_at%22%3A%20%222015-12-09T01%3A58%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-09T01%3A58%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20content/blaze.md%3AL1-544%22%7D%2C%20%22Pull%20b9291f572b55c3a2226763991b8268d67efd7384%20content/blaze.md%20427%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47042585%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22If%20we%20fetch%20data%20in%20helpers%20from%20the%20database%2C%20why%20not%20fetch%20router%20data%20in%20there%20too%3F%20Alternatively%2C%20we%20could%20suggest%20wrapping%20cursors%20in%20functions%20in%20%60onCreated%60%20but%20that%20could%20be%20a%20bit%20much.%20This%20is%20making%20me%20think%20that%20accessing%20the%20router%20from%20the%20helper%20is%20OK.%22%2C%20%22created_at%22%3A%20%222015-12-09T01%3A47%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20think%20we%20agree%20on%20this.%22%2C%20%22created_at%22%3A%20%222015-12-09T01%3A59%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-09T01%3A59%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20content/blaze.md%3AL1-544%22%7D%2C%20%22Pull%20315ccaca1f3a767c75da9e70dc6d8a57393b49af%20content/blaze.md%20233%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47056605%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22It%20does%20work%2C%20right%3F%20So%20we%20can%20drop%20the%20XXX%22%2C%20%22created_at%22%3A%20%222015-12-09T06%3A59%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222015-12-11T04%3A07%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20content/blaze.md%3AL1-560%22%7D%2C%20%22Pull%20b9291f572b55c3a2226763991b8268d67efd7384%20content/blaze.md%20402%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47042150%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Would%20also%20be%20good%20to%20mention%20the%20UX%20article%20about%20reusable/smart%20components%22%2C%20%22created_at%22%3A%20%222015-12-09T01%3A41%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-09T02%3A24%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20content/blaze.md%3AL1-544%22%7D%2C%20%22Pull%20b9291f572b55c3a2226763991b8268d67efd7384%20content/blaze.md%20467%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47042804%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Somewhere%20near%20the%20top%20of%20this%20we%20should%20mention%20that%20the%20intention%20is%20that%20helpers%20should%20be%20cheap%20to%20re-run%22%2C%20%22created_at%22%3A%20%222015-12-09T01%3A50%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22Added%20something%2C%20lmk%22%2C%20%22created_at%22%3A%20%222015-12-09T02%3A02%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-09T02%3A29%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20content/blaze.md%3AL1-544%22%7D%2C%20%22Pull%20b9291f572b55c3a2226763991b8268d67efd7384%20content/blaze.md%2040%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r46922856%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%5C%22will%20never%20render%20HTML%5C%22%20-%3E%20%5C%22will%20escape%20HTML%20for%20you%5C%22%5Cr%5Cn%5Cr%5CnI%20think%20any%20reasonable%20person%20would%20say%20they%20do%20render%20HTML%22%2C%20%22created_at%22%3A%20%222015-12-08T07%3A43%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-09T01%3A06%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20content/blaze.md%3AL1-544%22%7D%2C%20%22Pull%20315ccaca1f3a767c75da9e70dc6d8a57393b49af%20content/blaze.md%2075%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r47056363%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Technically%2C%20%60todo%60%20is%20not%20in%20the%20data%20context%20since%20it%27s%20a%20lexical%20variable%20introduced%20by%20%60each%20in%60.%20Not%20sure%20how%20technically%20correct%20we%20need%20to%20be.%22%2C%20%22created_at%22%3A%20%222015-12-09T06%3A54%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22In%20the%20place%20where%20I%20use%20%60%7B%7Btodo.title%7D%7D%60%20it%20%2Ais%2A%20the%20data%20context%20%28b/c%20it%27s%20the%20%60todosItem%60%20template%29.%5Cr%5Cn%5Cr%5CnSo%20strictly%20speaking%20it%20is%20correct.%22%2C%20%22created_at%22%3A%20%222015-12-11T04%3A12%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222015-12-11T19%3A02%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20content/blaze.md%3AL1-560%22%7D%2C%20%22Pull%20b9291f572b55c3a2226763991b8268d67efd7384%20content/blaze.md%20173%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r46924114%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22End%20template%20tag%22%2C%20%22created_at%22%3A%20%222015-12-08T08%3A03%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-09T01%3A22%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20content/blaze.md%3AL1-544%22%7D%2C%20%22Pull%20b9291f572b55c3a2226763991b8268d67efd7384%20content/blaze.md%20179%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r46924129%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22H4%27s%20don%27t%20need%20IDs%22%2C%20%22created_at%22%3A%20%222015-12-08T08%3A04%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22Can%20we%20not%20still%20link%20to%20them%20though%3F%22%2C%20%22created_at%22%3A%20%222015-12-09T01%3A23%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22Not%20currently%2C%20but%20we%20could%20add%20that%20feature.%20Should%20we%3F%22%2C%20%22created_at%22%3A%20%222015-12-09T01%3A37%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20mean%2C%20can%20we%20literally%20not%20link%20to%20them%3F%20I%20think%20we%20can%3F%22%2C%20%22created_at%22%3A%20%222015-12-09T01%3A53%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes%2C%20that%27s%20true%20-%20you%20could%20manually%20add%20the%20ID%20in%20the%20URL.%20I%20just%20mean%20that%20the%20little%20link%20button%20doesn%27t%20show%20up.%20I%27ll%20need%20to%20modify%20my%20H4s%20to%20have%20good%20IDs%20then.%22%2C%20%22created_at%22%3A%20%222015-12-09T01%3A56%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-09T02%3A24%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20content/blaze.md%3AL1-544%22%7D%2C%20%22Pull%20b9291f572b55c3a2226763991b8268d67efd7384%20content/blaze.md%20380%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r46924901%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Should%20this%20be%20%60Template.instance%28%29.data.onEdit%60%3F%20If%20you%20use%20any%20of%20the%20data%20context%20changing%20block%20helpers%20it%20won%27t%20work%20anymore.%22%2C%20%22created_at%22%3A%20%222015-12-08T08%3A14%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yeah%20but%20we%20say%20not%20to%20do%20that.%20I%27m%20not%20sure.%22%2C%20%22created_at%22%3A%20%222015-12-09T01%3A51%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-12-09T02%3A38%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20content/blaze.md%3AL1-544%22%7D%2C%20%22Pull%20b9291f572b55c3a2226763991b8268d67efd7384%20content/blaze.md%20132%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/139%23discussion_r46923988%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60attributes%28%29%20%7B%20...%20%7D%60%2C%20not%20arrow%20function%20here%22%2C%20%22created_at%22%3A%20%222015-12-08T08%3A02%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-09T01%3A22%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20content/blaze.md%3AL1-544%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull b9291f572b55c3a2226763991b8268d67efd7384 content/blaze.md 438'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/139#discussion_r47042669'>File: content/blaze.md:L1-544</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> I'm not sure what this is recommending - should the functionality be factored out into a wrapper component?
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> Oh, I guess I was thinking of composition, if you can figure out a way to make it a child component. A wrapper component is sort of like complex composition, works too..
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> I should probably think of an example here and demo it. Any ideas?
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> I guess a common thing can be having some complex state or event handler logic. For example, you want to do auto-completing user search, and you want this to work inside a text area to tag users, or in a user selector somewhere.
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> Hrmm, need a better example for composition. Something not immediately obvious where you would pull out a sub-component if you wanted to share functionality.
I think this example doesn't really work as a subcomponent -- what would the component render?
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> I feel like we just need to go look at examples where people want to use template-extension or blaze components and talk about how to do them with composition.
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> I added something. It's pretty crappy though.
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> It doesn't look like you pushed this change. After this we can merge! Thanks for doing this article, must have been a slog
- [x] <a href='#crh-comment-Pull b9291f572b55c3a2226763991b8268d67efd7384 content/blaze.md 7'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/139#discussion_r46922770'>File: content/blaze.md:L1-544</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Hmm, technically they are Spacebars templates, Blaze is just the underlying rendering engine... what do you think? Too pedantic? People use the word "Blaze" to refer to the whole thing these days.
- [x] <a href='#crh-comment-Pull b9291f572b55c3a2226763991b8268d67efd7384 content/blaze.md 40'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/139#discussion_r46922856'>File: content/blaze.md:L1-544</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> "will never render HTML" -> "will escape HTML for you"
I think any reasonable person would say they do render HTML
- [x] <a href='#crh-comment-Pull b9291f572b55c3a2226763991b8268d67efd7384 content/blaze.md 52'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/139#discussion_r46923841'>File: content/blaze.md:L1-544</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Data context of the element where the helper was used, not the template.
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Also, I feel like we should discourage using `this` inside helpers in favor of passing arguments or using `Template.instance().data`
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> What do you think now?
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> I don't think you pushed your change yet.
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> Yeah I write the comments as I go through the file and then push at the end, sorry. Pushed now.
- [x] <a href='#crh-comment-Pull b9291f572b55c3a2226763991b8268d67efd7384 content/blaze.md 122'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/139#discussion_r46923962'>File: content/blaze.md:L1-544</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> "include an object as part of an HTML to apply multiple properties at once:" -> "Include an object in the attribute list of an HTML element to set multiple attributes at once."
- [x] <a href='#crh-comment-Pull b9291f572b55c3a2226763991b8268d67efd7384 content/blaze.md 132'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/139#discussion_r46923988'>File: content/blaze.md:L1-544</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> `attributes() { ... }`, not arrow function here
- [x] <a href='#crh-comment-Pull b9291f572b55c3a2226763991b8268d67efd7384 content/blaze.md 142'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/139#discussion_r46924033'>File: content/blaze.md:L1-544</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> mustance -> mustache
- [x] <a href='#crh-comment-Pull b9291f572b55c3a2226763991b8268d67efd7384 content/blaze.md 159'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/139#discussion_r46924063'>File: content/blaze.md:L1-544</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> `eachBlock` -> `elseBlock`
- [x] <a href='#crh-comment-Pull b9291f572b55c3a2226763991b8268d67efd7384 content/blaze.md 173'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/139#discussion_r46924114'>File: content/blaze.md:L1-544</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> End template tag
- [x] <a href='#crh-comment-Pull b9291f572b55c3a2226763991b8268d67efd7384 content/blaze.md 179'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/139#discussion_r46924129'>File: content/blaze.md:L1-544</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> H4's don't need IDs
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> Can we not still link to them though?
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Not currently, but we could add that feature. Should we?
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> I mean, can we literally not link to them? I think we can?
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Yes, that's true - you could manually add the ID in the URL. I just mean that the little link button doesn't show up. I'll need to modify my H4s to have good IDs then.
- [x] <a href='#crh-comment-Pull b9291f572b55c3a2226763991b8268d67efd7384 content/blaze.md 211'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/139#discussion_r46924201'>File: content/blaze.md:L1-544</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> I'd add a "historical note".
Also, is it confusing that you can't access `name` or `color` above from a helper?
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> Let me know what you think.
- [x] <a href='#crh-comment-Pull b9291f572b55c3a2226763991b8268d67efd7384 content/blaze.md 217'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/139#discussion_r46924273'>File: content/blaze.md:L1-544</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Whoa, I had no idea... this would really simplify some stuff in the docs app lol
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> This is like basically copied out of the spacebars docs.
- [x] <a href='#crh-comment-Pull b9291f572b55c3a2226763991b8268d67efd7384 content/blaze.md 214'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/139#discussion_r46924305'>File: content/blaze.md:L1-544</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> You also need to close tags that don't need to be closed in HTML5, like `<p>`.
- [x] <a href='#crh-comment-Pull b9291f572b55c3a2226763991b8268d67efd7384 content/blaze.md 239'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/139#discussion_r46924409'>File: content/blaze.md:L1-544</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> 
```js
new SimpleSchema({
list: {blackbox: true},
todosReady: {type: Boolean}
}).validate(Template.data());
```
This works fine, we don't need to call `check`.
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> Yeah. We just need to make sure it actually works (right now it throws due to the `list` failing the object test)
- [x] <a href='#crh-comment-Pull b9291f572b55c3a2226763991b8268d67efd7384 content/blaze.md 243'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/139#discussion_r46924466'>File: content/blaze.md:L1-544</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> This sentence is janky
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> Hmm, what would you say instead?
- [x] <a href='#crh-comment-Pull b9291f572b55c3a2226763991b8268d67efd7384 content/blaze.md 258'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/139#discussion_r46924524'>File: content/blaze.md:L1-544</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> sub-component -> sub-template? Not sure if we are using the word component to refer to Blaze entities
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> I think I'm pretty inconsistent in this article. I've used component more or less everywhere else in the guide. It's hard to know what to use in this article, sometimes it seems like it should be component (like when talking about "reusability"), other times template (when talking about technicalities with Blaze).
This is sort of in-between.
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> Switched to try and use component everywhere it makes any kind of sense.
It's a bit wonky but probably the best of bad options.
- [x] <a href='#crh-comment-Pull b9291f572b55c3a2226763991b8268d67efd7384 content/blaze.md 261'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/139#discussion_r46924580'>File: content/blaze.md:L1-544</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> "Although Blaze doesn't currently have a fully baked component model" is overly negative IMO. Plus I bet certain people would disagree with this statement.
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> Better?
- [x] <a href='#crh-comment-Pull b9291f572b55c3a2226763991b8268d67efd7384 content/blaze.md 272'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/139#discussion_r46924665'>File: content/blaze.md:L1-544</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> `doEdit` is a super weird variable name. Not sure what it does. Maybe this is `onFocusChange` and `focusStatus` or `onEditingStateChange` and `editingState`? Or maybe even `onFocus`/`onBlur`.
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> How about just `onEditingChange` and `editing`?
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Sounds good!
- [x] <a href='#crh-comment-Pull b9291f572b55c3a2226763991b8268d67efd7384 content/blaze.md 380'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/139#discussion_r46924901'>File: content/blaze.md:L1-544</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Should this be `Template.instance().data.onEdit`? If you use any of the data context changing block helpers it won't work anymore.
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> Yeah but we say not to do that. I'm not sure.
- [x] <a href='#crh-comment-Pull b9291f572b55c3a2226763991b8268d67efd7384 content/blaze.md 402'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/139#discussion_r47042150'>File: content/blaze.md:L1-544</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Would also be good to mention the UX article about reusable/smart components
- [x] <a href='#crh-comment-Pull b9291f572b55c3a2226763991b8268d67efd7384 content/blaze.md 420'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/139#discussion_r47042317'>File: content/blaze.md:L1-544</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> It's `{{Template.subscriptionsReady}}` inside Spacebars, and `Template.instance().subscriptionsReady()` inside helpers.
- [x] <a href='#crh-comment-Pull b9291f572b55c3a2226763991b8268d67efd7384 content/blaze.md 424'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/139#discussion_r47042496'>File: content/blaze.md:L1-544</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> I guess the logic is, we want to do all "smart" things inside `onCreated` rather than inside helpers? One more way to achieve that would be to define a function inside `onCreated` like:
```js
this.getListId = () => FlowRouter.getParam('_id')
this.autorun(() => {
this.subscribe('list/todos', this.getListId());
});
```
And then use that function inside the helper. That way if you need to get the listId from somewhere else, you don't need to change the helper?
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> That seems like a very sensible approach, I'll make that change.
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> https://github.com/meteor/todos/commit/eabfb2535a393476c870373b8eb105bf08d3d315
- [x] <a href='#crh-comment-Pull b9291f572b55c3a2226763991b8268d67efd7384 content/blaze.md 427'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/139#discussion_r47042585'>File: content/blaze.md:L1-544</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> If we fetch data in helpers from the database, why not fetch router data in there too? Alternatively, we could suggest wrapping cursors in functions in `onCreated` but that could be a bit much. This is making me think that accessing the router from the helper is OK.
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> I think we agree on this.
- [x] <a href='#crh-comment-Pull b9291f572b55c3a2226763991b8268d67efd7384 content/blaze.md 467'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/139#discussion_r47042804'>File: content/blaze.md:L1-544</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Somewhere near the top of this we should mention that the intention is that helpers should be cheap to re-run
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> Added something, lmk
- [x] <a href='#crh-comment-Pull 1cc46ddc6efbc431ff7243bb3a73a28c36863b20 content/blaze.md 249'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/139#discussion_r47045382'>File: content/blaze.md:L1-561</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> We use an `autorun()` to make sure that the data context is validated again whenever it changes.
- [x] <a href='#crh-comment-Pull 315ccaca1f3a767c75da9e70dc6d8a57393b49af content/blaze.md 75'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/139#discussion_r47056363'>File: content/blaze.md:L1-560</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Technically, `todo` is not in the data context since it's a lexical variable introduced by `each in`. Not sure how technically correct we need to be.
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> In the place where I use `{{todo.title}}` it *is* the data context (b/c it's the `todosItem` template).
So strictly speaking it is correct.
- [x] <a href='#crh-comment-Pull 315ccaca1f3a767c75da9e70dc6d8a57393b49af content/blaze.md 80'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/139#discussion_r47056438'>File: content/blaze.md:L1-560</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> I'd specifically call out `kws.hash` in the text. It's a bit odd and deserves clarification. I'd even go so far as to suggest avoiding keyword arguments to helpers for clarity?
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> Changed..
- [x] <a href='#crh-comment-Pull 315ccaca1f3a767c75da9e70dc6d8a57393b49af content/blaze.md 140'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/139#discussion_r47056531'>File: content/blaze.md:L1-560</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> "won't render any HTML" -> "will escape HTML tags to avoid XSS"
"you can render pure HTML" -> "you can render raw HTML"
- [x] <a href='#crh-comment-Pull 315ccaca1f3a767c75da9e70dc6d8a57393b49af content/blaze.md 192'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/139#discussion_r47056579'>File: content/blaze.md:L1-560</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Should we add an example of a two-dimensional iteration? That's the main strength of `each in` over old `each`.
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> Is this better?
- [x] <a href='#crh-comment-Pull 315ccaca1f3a767c75da9e70dc6d8a57393b49af content/blaze.md 233'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/139#discussion_r47056605'>File: content/blaze.md:L1-560</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> It does work, right? So we can drop the XXX


<a href='https://www.codereviewhub.com/meteor/guide/pull/139?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/meteor/guide/pull/139?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/meteor/guide/pull/139'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>