### PR TITLE
Fix typos in security.md

### DIFF
--- a/content/build-tool.md
+++ b/content/build-tool.md
@@ -18,7 +18,7 @@ The main function of the Meteor build tool is to run "build plugins" - these plu
 
 ### Combines and minifies code
 
-Another important feature of the Meteor build tool is that it automatically concatenates and minifies all of your files in production mode. This is enabled by the `standard-minifiers` pacakge, which is in all Meteor apps by default. If you need different minification behavior, you can replace this package. Below, we'll talk about how to switch out your minifier to add PostCSS to your build process.
+Another important feature of the Meteor build tool is that it automatically concatenates and minifies all of your files in production mode. This is enabled by the `standard-minifiers` package, which is in all Meteor apps by default. If you need different minification behavior, you can replace this package. Below, we'll talk about how to switch out your minifier to add PostCSS to your build process.
 
 ### Development vs. production
 
@@ -40,8 +40,8 @@ Don't use Bower XXX link to some article explaining that people are moving to NP
 
 You have two options for adding packages from Atmosphere to your app:
 
-1. Use the command line: `meteor add kadira:flow-router`
-2. Edit the file in your app under `.meteor/packages`, and add the package name anywhere in the file
+1. Use the command line: `meteor add kadira:flow-router`.
+2. Edit the file in your app under `.meteor/packages`, and add the package name anywhere in the file.
 
 These options will add the newest version of the desired package that is compatible with the other packages in your app. If you want to specify a particular version, you can specify it by adding a suffix to the package name, like so: `meteor add kadira:flow-router@2.10.0`.
 
@@ -53,15 +53,15 @@ If your app is running when you add a new package, Meteor will automatically dow
 
 There are a few ways to search for Meteor packages published to Atmosphere:
 
-1. Search on the [Atmosphere website](https://atmospherejs.com/)
-2. Use `meteor search` from the command line
-3. Use a community package search website like [Fastosphere](http://fastosphere.meteor.com/)
+1. Search on the [Atmosphere website](https://atmospherejs.com/).
+2. Use `meteor search` from the command line.
+3. Use a community package search website like [Fastosphere](http://fastosphere.meteor.com/).
 
-The main Atmosphere website provides additional curation features like trending packages, package stars, and flags, but some of the other options can be faster if you're trying to find a specific package. You can also use `meteor show kadira:flow-router` from the command line to see the description of a package and different available versions.
+The main Atmosphere website provides additional curation features like trending packages, package stars, and flags, but some of the other options can be faster if you're trying to find a specific package. For example, you can use `meteor show kadira:flow-router` from the command line to see the description of that package and different available versions.
 
 #### Package naming
 
-You may notice that all packages on Atmosphere have a name of the form `prefix:name`. The prefix is the name of the organization or user that published the package. Meteor uses such a convention of package naming to make sure that it's clear who has published a certain package, and to avoid an ad-hoc namespacing convention.
+You may notice that, with the exception of Meteor platform packages, all packages on Atmosphere have a name of the form `prefix:name`. The prefix is the name of the organization or user that published the package. Meteor uses such a convention of package naming to make sure that it's clear who has published a certain package, and to avoid an ad-hoc namespacing convention. Meteor platform packages do not have any `prefix:`.
 
 #### Overriding packages from Atmosphere with a local version
 
@@ -69,7 +69,7 @@ A Meteor app can load packages in one of three ways:
 
 1. Downloading a pre-built package from Atmosphere. The package is cached in `~/.meteor/packages` on Mac/Linux or `%LOCALAPPDATA%/.meteor/packages`, and only loaded into your app as it is built.
 2. Loading the package's source code into a `packages/` directory inside your app. This lets you modify the source code of the package for your particular needs.
-3. Defining a `PACKAGE_DIRS` environment variable before running any `meteor` command. You can add multiple directories by separating the paths with a `:`. Ex: `PACKAGE_DIRS=../first/directory:../second/directory meteor`
+3. Defining a `PACKAGE_DIRS` environment variable before running any `meteor` command. You can add multiple directories by separating the paths with a `:` on OSX or Linux, or a `;` on Windows. For example: `PACKAGE_DIRS=../first/directory:../second/directory`, or on Windows: `set PACKAGE_DIRS=..\first\directory;..\second\directory`.
 
 When `meteor` searches for a package listed in the `~/.meteor/packages` file, it will look inside of the app's `packages/` directory first. Second, it will search inside of any directories defined in `PACKAGE_DIRS` environment variable. Lastly, it will search for the package on Atmosphere.
 

--- a/content/build-tool.md
+++ b/content/build-tool.md
@@ -67,7 +67,7 @@ You may notice that, with the exception of Meteor platform packages, all package
 
 A Meteor app can load packages in one of three ways:
 
-1. Downloading a pre-built package from Atmosphere. The package is cached in `~/.meteor/packages` on Mac/Linux or `%LOCALAPPDATA%/.meteor/packages`, and only loaded into your app as it is built.
+1. Downloading a pre-built package from Atmosphere. The package is cached in `~/.meteor/packages` on Mac/Linux or `%LOCALAPPDATA%\.meteor\packages` on Windows, and only loaded into your app as it is built.
 2. Loading the package's source code into a `packages/` directory inside your app. This lets you modify the source code of the package for your particular needs.
 3. Defining a `PACKAGE_DIRS` environment variable before running any `meteor` command. You can add multiple directories by separating the paths with a `:` on OSX or Linux, or a `;` on Windows. For example: `PACKAGE_DIRS=../first/directory:../second/directory`, or on Windows: `set PACKAGE_DIRS=..\first\directory;..\second\directory`.
 

--- a/content/data-loading.md
+++ b/content/data-loading.md
@@ -114,7 +114,7 @@ Subscribing to data puts it in your client-side collections. To use the data in 
 
   If you don't do this, then you open yourself up to problems if another subscription pushes data into the same collection. Although you may be confident that this is not the case, in an actively developed application, it's impossible to anticipate what may change in the future and this can be a source of hard to understand bugs.
 
-  Also, when changing subscriptions, there is a brief period where both subscriptions are loaded (see "Publication behaviour when changing arguments" below), so when doing thing like pagination, it's exceedingly likely that this will be the case.
+  Also, when changing subscriptions, there is a brief period where both subscriptions are loaded (see "Publication behavior when changing arguments" below), so when doing thing like pagination, it's exceedingly likely that this will be the case.
 
 2. Fetch the data as close as possible to where you subscribe to it.
 
@@ -182,7 +182,7 @@ The important detail in the above is in 4---that they system cleverly knows not 
 
 For instance if a user navigates between two pages that both subscribe to the exact same subscription, the same mechanism will kick in and no unnecessary subscribing will happen.
 
-<h3 id="publication-behaviour-with-arguments">Publication behavior when arguments change</h3>
+<h3 id="publication-behavior-with-arguments">Publication behavior when arguments change</h3>
 
 It's also worth knowing a little about what happens on the server when the new subscription is started and the old one is stopped.
 
@@ -337,7 +337,7 @@ Meteor.publish('list/todos', function(listId) {
 
 However, this example will not work as you might expect. The reason is that reactivity doesn't work in the same way on the server as it does on the client. On the client, if *anything* in a reactive function changes, the whole function will re-run, and the results are fairly intuitive.
 
-On the server however, the reactivity is limited to the behaviour of the cursors you return from your publish functions. You'll see any changes to the data that matches their queries, but *their queries will never change*.
+On the server however, the reactivity is limited to the behavior of the cursors you return from your publish functions. You'll see any changes to the data that matches their queries, but *their queries will never change*.
 
 So in the case above, if a user subscribes to a list that is later made private by another user, although the `list.userId` will change to a value that no longer passes the condition, the body of the publication will not re-run, and so the query to the `Todos` collection (`{listId}`) will not change. So the first user will continue to see items they shouldn't.
 

--- a/content/methods.md
+++ b/content/methods.md
@@ -4,10 +4,10 @@ title: "Methods"
 
 After reading this article, you'll know:
 
-1. What Methods are in Meteor and how they work in detail
-2. Best practices for defining and calling Methods
-3. How to throw and handle errors with Methods
-4. How to call a method from a form
+1. What Methods are in Meteor and how they work in detail.
+2. Best practices for defining and calling Methods.
+3. How to throw and handle errors with Methods.
+4. How to call a Method from a form.
 
 ## What is a Method?
 
@@ -15,7 +15,7 @@ Methods are Meteor's remote procedure call (RPC) system, used to save user input
 
 At its core, a Method is an API endpoint for your server; you can define a Method on the server and its counterpart on the client, then call it with some data, write to the database, and get the return value in a callback. Meteor Methods are also tightly integrated with the pub/sub and data loading systems of Meteor to allow for [Optimistic UI](http://info.meteor.com/blog/optimistic-ui-with-meteor-latency-compensation) - the ability to simulate server-side actions on the client to make your app feel faster than it actually is.
 
-We'll referring to Meteor Methods with a capital M to differentiate them from class methods in JavaScript.
+We'll be referring to Meteor Methods with a capital M to differentiate them from class methods in JavaScript.
 
 ## Defining and calling Methods
 
@@ -27,7 +27,7 @@ In a basic app, defining a Meteor Method is as simple as defining a function. In
 
 Here's how you can use the built-in [`Meteor.methods` API](http://docs.meteor.com/#/full/meteor_methods) to define a Method. Note that Methods should always be defined in common code loaded on the client and the server to enable Optimistic UI. If you have some secret code in your Method, consult the [Security article](security.md#secret-code) for how to hide it from the client.
 
-This example uses the `aldeed:simple-schema` package, which is recommended in several other articles, to validate the method arguments.
+This example uses the `aldeed:simple-schema` package, which is recommended in several other articles, to validate the Method arguments.
 
 ```js
 Meteor.methods({
@@ -53,7 +53,7 @@ Meteor.methods({
 
 #### Calling
 
-This method is callable from the client and server using [`Meteor.call`](http://docs.meteor.com/#/full/meteor_call). Note that you should only use a Method in the case where some code needs to be callable from the client; if you just want to modularize code that is only going to be called from the server, use a regular JavaScript function, not a Method.
+This Method is callable from the client and server using [`Meteor.call`](http://docs.meteor.com/#/full/meteor_call). Note that you should only use a Method in the case where some code needs to be callable from the client; if you just want to modularize code that is only going to be called from the server, use a regular JavaScript function, not a Method.
 
 Here's how you can call this Method from the client:
 
@@ -76,14 +76,14 @@ If the Method throws an error, you get that in the first argument of the callbac
 
 Meteor Methods have several features which aren't immediately obvious, but every complex app will need them at some point. These features were added incrementally over several years in a backwards-compatible fashion, so unlocking the full capabilities of Methods requires a good amount of boilerplate. In this article we will first show you all of the code you need to write for each feature, then the next section will talk about a Method wrapper package we have developed to make it easier.
 
-Here are some of the functionality an ideal Method would have:
+Here's some of the functionality an ideal Method would have:
 
-1. Run validation code by itself without running the Method body
-2. Easily override the Method for testing
-3. Easily call the Method with a custom user ID, especially in tests (as recommended by the [Discover Meteor two-tiered methods pattern](https://www.discovermeteor.com/blog/meteor-pattern-two-tiered-methods/))
-4. Refer to the Method via JS module rather than a magic string
-5. Get the Method simulation return value to get IDs of inserted documents
-6. Avoid calling the server-side Method if the client-side validation failed, so we don't waste server resources
+1. Run validation code by itself without running the Method body.
+2. Easily override the Method for testing.
+3. Easily call the Method with a custom user ID, especially in tests (as recommended by the [Discover Meteor two-tiered methods pattern](https://www.discovermeteor.com/blog/meteor-pattern-two-tiered-methods/)).
+4. Refer to the Method via JS module rather than a magic string.
+5. Get the Method simulation return value to get IDs of inserted documents.
+6. Avoid calling the server-side Method if the client-side validation failed, so we don't waste server resources.
 
 #### Defining
 
@@ -103,7 +103,7 @@ Todos.methods.updateText = {
     }).validate(args)
   },
 
-  // Factor out method body so that it can be called independently (3)
+  // Factor out Method body so that it can be called independently (3)
   run({ todoId, newText }) {
     const todo = Todos.findOne(todoId);
 
@@ -117,7 +117,7 @@ Todos.methods.updateText = {
     });
   },
 
-  // Call method by referencing the JS object (4)
+  // Call Method by referencing the JS object (4)
   // Also, this lets us specify Meteor.apply options once in
   // the Method implementation, rather than requiring the caller
   // to specify it at the call site.
@@ -134,10 +134,10 @@ Todos.methods.updateText = {
 
 #### Calling
 
-Now calling the method is as simple as calling a JavaScript function:
+Now calling the Method is as simple as calling a JavaScript function:
 
 ```js
-// Call the method
+// Call the Method
 Todos.methods.updateText.call({
   todoId: '12345',
   newText: 'This is a todo item.'
@@ -152,7 +152,7 @@ Todos.methods.updateText.call({
 // Call the validation only
 Todos.methods.updateText.validate();
 
-// Call the method with custom userId in a test
+// Call the Method with custom userId in a test
 Todos.methods.updateText.run.call({ userId: 'abcd' }, {
   todoId: '12345',
   newText: 'This is a todo item.'
@@ -163,7 +163,7 @@ As you can see, this approach to calling Methods results in a better development
 
 ### Advanced Methods with mdg:validated-method
 
-To alleviate some of the boilerplate that's involved in correct Method definitions, we've published a wrapper package called `mdg:validated-method` that does most of this for you. Here's the same method as above, but defined with the package:
+To alleviate some of the boilerplate that's involved in correct Method definitions, we've published a wrapper package called `mdg:validated-method` that does most of this for you. Here's the same Method as above, but defined with the package:
 
 ```js
 Todos.methods.updateText = new ValidatedMethod({
@@ -187,7 +187,7 @@ Todos.methods.updateText = new ValidatedMethod({
 });
 ```
 
-You call it the same way you call the advanced method above, but the Method definition is significantly simpler. We believe this style of Method lets you clearly see the important parts - the name of the Method sent over the wire, the format of the expected arguments, and the JavaScript namespace by which the Method can be referenced.
+You call it the same way you call the advanced Method above, but the Method definition is significantly simpler. We believe this style of Method lets you clearly see the important parts - the name of the Method sent over the wire, the format of the expected arguments, and the JavaScript namespace by which the Method can be referenced.
 
 ## Error handling
 
@@ -224,7 +224,7 @@ Read more about the error format in the [`mdg:validation-error` docs](https://at
 When you call a Method, any errors thrown by it will be returned in the callback. At this point, you should identify which error type it is and display the appropriate message to the user. In this case, it is unlikely that the Method will throw a `ValidationError` or an internal server error, so we will only handle the unauthorized error:
 
 ```js
-// Call the method
+// Call the Method
 Todos.methods.updateText.call({
   todoId: '12345',
   newText: 'This is a todo item.'
@@ -252,7 +252,7 @@ We'll talk about how to handle the `ValidationError` in the section on forms bel
 The main thing enabled by the `ValidationError` convention is simple integration between Methods and the forms that call them. In general, your app is likely to have a one-to-one mapping of forms in the UI to Methods. First, let's define a Method for our business logic:
 
 ```js
-// This method encodes the form validation requirements.
+// This Method encodes the form validation requirements.
 // By defining them in the Method, we do client and server-side
 // validation in one place.
 Invoices.methods.insert = new ValidatedMethod({
@@ -357,7 +357,7 @@ As you can see, there is a fair amount of boilerplate to handle errors nicely in
 
 ## Loading data with Methods
 
-Since Methods can work as general purpose RPCs, they can also be used to fetch data instead of publications. There are some advantages and some disadvantages to this approach compared to loading data through publications, and at the end of the day we recommend always using publications to load data.
+Since Methods can work as general purpose RPCs, they can also be used to fetch data instead of publications. There are some advantages and some disadvantages to this approach compared with loading data through publications, and at the end of the day we recommend always using publications to load data.
 
 Methods can be useful to fetch the result of a complex computation from the server that doesn't need to update when the server data changes. The biggest disadvantage of fetching data through Methods is that the data won't be automatically loaded into Minimongo, Meteor's client-side data cache, so you'll need to manage the lifecycle of that data manually.
 
@@ -380,7 +380,7 @@ function updateAverages() {
   // Clean out result cache
   ScoreAverages.remove({});
 
-  // Call a method that does an expensive computation
+  // Call a Method that does an expensive computation
   Games.methods.calculateAverages.call((err, res) => {
     res.forEach((item) => {
       ScoreAverages.insert(item);
@@ -397,13 +397,13 @@ While you can easily use Methods in a simple app by following the Meteor introdu
 
 ### Method call lifecycle
 
-Here's exactly what happens, in order, when a method is called:
+Here's exactly what happens, in order, when a Method is called:
 
-1. **Method simulation runs on the client.** If we defined this method in client and server code, as all Methods should be, the first thing Meteor does is it executes the Method code in the client that called it. This is known as a "method simulation" - the client enters a special mode where it tracks all changes made to client-side collections, so that they can be rolled back later. When this step is complete, the user of your app sees their UI update instantly with the new content of the client-side database, but the server hasn't received any data yet. The return value of the Method simulation is discarded, unless the `returnStubValue` option is passed when calling the Method. ValidatedMethod passes this option by default.
+1. **Method simulation runs on the client.** If we defined this Method in client and server code, as all Methods should be, the first thing Meteor does is it executes the Method code in the client that called it. This is known as a "Method simulation" - the client enters a special mode where it tracks all changes made to client-side collections, so that they can be rolled back later. When this step is complete, the user of your app sees their UI update instantly with the new content of the client-side database, but the server hasn't received any data yet. The return value of the Method simulation is discarded, unless the `returnStubValue` option is passed when calling the Method. ValidatedMethod passes this option by default.
 2. **A `method` message is sent to the server.** The Meteor client constructs a DDP message to send to the server. This includes the Method name, arguments, and an automatically generated Method ID that represents this particular Method invocation.
-3. **Method runs on the server.** When the server receives the message, it executes the Method code again. The client side version was a simulation that will be rolled back later, but this time is the real version that is writing to the actual database. Running the actual Method logic on the server is crucial because the server is a trusted environment where we can know that security-critical code will run the way we expect.
+3. **Method runs on the server.** When the server receives the message, it executes the Method code again. The client side version was a simulation that will be rolled back later, but this time it's the real version that is writing to the actual database. Running the actual Method logic on the server is crucial because the server is a trusted environment where we can know that security-critical code will run the way we expect.
 4. **Return value is sent to the client.** Once the Method has finished running on the server, it sends a `result` message to the client with the Method ID generated in step 2, and the return value itself. The client stores this for later use, but _doesn't call the Method callback yet_. If you pass the [`onResultReceived` option to `Meteor.apply`](http://docs.meteor.com/#/full/meteor_apply), that callback is fired.
-5. **Any DDP publications affected by the method are updated.** If we have any publications on the page that have been affected by the database writes from this Method, the server sends the appropriate updates to the client. Note that the client data system does not yet send these updates to the app UI until the next step.
+5. **Any DDP publications affected by the Method are updated.** If we have any publications on the page that have been affected by the database writes from this Method, the server sends the appropriate updates to the client. Note that the client data system does not yet send these updates to the app UI until the next step.
 6. **`updated` message sent to the client, data replaced with server result, Method callback fires.** After the relevant data updates have been sent to the correct client, the server sends back the last message in the Method life cycle - the DDP `updated` message with the relevant Method ID. The client rolls back any changes to client side data made in the Method simulation in step 1, and replaces them with the actual changes sent from the server in step 5. At this point, the callback passed to `Meteor.call` actually fires with the return value from step 4. It's important that the callback waits until the client is up to date, so that your Method callback can assume that the client state reflects any changes done inside the Method.
 
 In the list above, we didn't cover the case when the Method execution on the server throws an error. In that case, there is no return value, and the client gets an error instead. The Method callback is fired instantly with the returned error as the first argument. Read more about error handling in the section about errors below.
@@ -412,16 +412,16 @@ In the list above, we didn't cover the case when the Method execution on the ser
 
 We believe Methods provide a much better primitive for building modern applications than REST endpoints built on HTTP. Let's go over some of the things you get for free with Methods that you would have to worry about if using HTTP. The purpose of this section is not to convince you that REST is bad - it's just to remind you that you don't need to handle these things yourself in a Meteor app.
 
-1. **Methods use synchronous-style APIs, but are non-blocking.** You may notice in the example method above, we didn't need to write any callbacks when interacting with MongoDB, but the Method still has the non-blocking properties that people associate with Node.js and callback-style code. Meteor uses a coroutine library called [Fibers](https://github.com/laverdet/node-fibers) to enable you to write code that uses return values and throws errors, and avoid dealing with lots of nested callbacks.
-2. **Methods always run and return in order.** When accessing a REST API, you will sometimes run into a situation where you make two requests one after the other, but the results arrive out of order. Meteor's underlying machinery makes sure this never happens with Methods. When multiple Method calls are received _from the same client_, Meteor runs each method to completion before starting the next one. If you need to disable this functionality for one particularly long-running Method, you can use [`this.unblock()`](http://docs.meteor.com/#/full/method_unblock) to allow the next Method to run while the current one is still in progress. Also, since Meteor is based on Websockets instead of HTTP, all Method calls and results are guaranteed to arrive in the order they are sent.
-3. **Change tracking for Optimistic UI.** When Method simulations and server-side executions run, Meteor tracks any resulting changes to the database. This is what lets the Meteor data system roll back the changes from the method simulation and replace them with the actual writes from the server. Without this automatic database tracking, it would be very difficult to implement a correct Optimistic UI system.
+1. **Methods use synchronous-style APIs, but are non-blocking.** You may notice in the example Method above, we didn't need to write any callbacks when interacting with MongoDB, but the Method still has the non-blocking properties that people associate with Node.js and callback-style code. Meteor uses a coroutine library called [Fibers](https://github.com/laverdet/node-fibers) to enable you to write code that uses return values and throws errors, and avoid dealing with lots of nested callbacks.
+2. **Methods always run and return in order.** When accessing a REST API, you will sometimes run into a situation where you make two requests one after the other, but the results arrive out of order. Meteor's underlying machinery makes sure this never happens with Methods. When multiple Method calls are received _from the same client_, Meteor runs each Method to completion before starting the next one. If you need to disable this functionality for one particularly long-running Method, you can use [`this.unblock()`](http://docs.meteor.com/#/full/method_unblock) to allow the next Method to run while the current one is still in progress. Also, since Meteor is based on Websockets instead of HTTP, all Method calls and results are guaranteed to arrive in the order they are sent.
+3. **Change tracking for Optimistic UI.** When Method simulations and server-side executions run, Meteor tracks any resulting changes to the database. This is what lets the Meteor data system roll back the changes from the Method simulation and replace them with the actual writes from the server. Without this automatic database tracking, it would be very difficult to implement a correct Optimistic UI system.
 
 ### Calling a Method from another Method
 
 Sometimes, you'll want to call a Method from another Method. Perhaps you already have some functionality implemented and you want to add a wrapper that fills in some of the arguments automatically. This is a totally fine pattern, and Meteor does some nice things for you:
 
 1. Inside a client-side Method simulation, calling another Method doesn't fire off an extra request to the server - the assumption is that the server-side implementation of the Method will do it. However, it does run the _simulation_ of the called Method, so that the simulation on the client closely matches what will happen on the server.
-2. Inside a method execution on the server, calling another Method runs that Method as if it were called by the same client. That means the Method runs as usual, and the context - `userId`, `connection`, etc - are taken from the original Method call.
+2. Inside a Method execution on the server, calling another Method runs that Method as if it were called by the same client. That means the Method runs as usual, and the context - `userId`, `connection`, etc - are taken from the original Method call.
 
 ### Consistent ID generation and optimistic UI
 
@@ -431,12 +431,12 @@ Each Meteor Method invocation shares a random generator seed with the client tha
 
 ### Method retries
 
-If you call a Method from the client, and the user's internet connection disconnects before the result is received, Meteor assumes that the Method didn't actually run. When the connection is re-established, the Method call will be sent again. This means that, in certain situations, Methods can be sent more than once. This should only happen very rarely, but in the case where an extra method call could have negative consequences it is worth putting in extra effort to ensure that Methods are idempotent - that is, calling them multiple times doesn't result in additional changes to the database.
+If you call a Method from the client, and the user's Internet connection disconnects before the result is received, Meteor assumes that the Method didn't actually run. When the connection is re-established, the Method call will be sent again. This means that, in certain situations, Methods can be sent more than once. This should only happen very rarely, but in the case where an extra Method call could have negative consequences it is worth putting in extra effort to ensure that Methods are idempotent - that is, calling them multiple times doesn't result in additional changes to the database.
 
 Many Method operations are idempotent by default. Inserts will throw an error if they happen twice because the generated ID will conflict. Removes on collections won't do anything the second time, and most update operators like `$set` will have the same result if run again. The only places you need to worry about code running twice are MongoDB update operators that stack, like `$inc` and `$push`, and calls to external APIs.
 
-### Historical comparison to allow/deny
+### Historical comparison with allow/deny
 
 The Meteor core API includes an alternative to Methods for manipulating data from the client. Instead of explicitly defining Methods with specific arguments, you can instead call `insert`, `update`, and `remove` directly from the client and specify security rules with [`allow`](http://docs.meteor.com/#/full/allow) and [`deny`](http://docs.meteor.com/#/full/deny). In the Meteor Guide, we are taking a strong position that this feature should be avoided and Methods used instead. Read more about the problems with allow/deny in the [Security article](security.html#allow-deny).
 
-Historically, there have been some misconceptions about the features of Meteor Methods as compared to the allow/deny feature, including that it was more difficult to achieve Optimistic UI when using Methods. However, the client-side `insert`, `update`, and `remove` feature is actually implemented _on top of_ Methods, so Methods are strictly more powerful. You get great default Optimistic UI just by defining your Method code on the client and the server, as described in the Method lifecycle section above.
+Historically, there have been some misconceptions about the features of Meteor Methods as compared with the allow/deny feature, including that it was more difficult to achieve Optimistic UI when using Methods. However, the client-side `insert`, `update`, and `remove` feature is actually implemented _on top of_ Methods, so Methods are strictly more powerful. You get great default Optimistic UI just by defining your Method code on the client and the server, as described in the Method lifecycle section above.

--- a/content/routing.md
+++ b/content/routing.md
@@ -4,18 +4,18 @@ title: "URLs and Routing"
 
 After reading this guide, you'll know:
 
-1. What role URLs play in a client-rendered app, and how it's different from a traditional server-rendered app
-2. How to define client and server routes for your app using Flow Router
-3. How to have your app display different content depending on the URL
-4. How to construct links to routes and go to routes programmatically
+1. What role URLs play in a client-rendered app, and how it's different from a traditional server-rendered app.
+2. How to define client and server routes for your app using Flow Router.
+3. How to have your app display different content depending on the URL.
+4. How to construct links to routes and go to routes programmatically.
 
 <h2 id="client-side">Client-side Routing</h2>
 
 In a web application, _routing_ is the process of using URLs to drive the user interface (UI). URLs are a prominent feature in every single web browser, and have several main functions from the user's point of view:
 
-1. **Bookmarking** - Users can bookmark URLs in their web browser to save content they want to come back to later
-2. **Sharing** - Users can share content with others by sending a link to a certain page
-3. **Navigation** - URLs are used to drive the web browser's back/forward functions
+1. **Bookmarking** - Users can bookmark URLs in their web browser to save content they want to come back to later.
+2. **Sharing** - Users can share content with others by sending a link to a certain page.
+3. **Navigation** - URLs are used to drive the web browser's back/forward functions.
 
 In a traditional web application stack, where the server renders HTML one page at a time, the URL is the fundamental entry point for the user to access the application. Users navigate an application by clicking through URLs, which are sent to the server via HTTP, and the server responds appropriately via a server-side router.
 
@@ -85,7 +85,7 @@ Note that all of the values in `params` and `queryParams` are always strings sin
 
 Flow Router makes a variety of information available via (reactive and otherwise) functions on the global singleton `FlowRouter` (this is the same object that we attached routes to above). As the user navigates around your app, the values of these functions will change (reactively in some cases) correspondingly.
 
-Like any other global singleton in your application (see the [data loading](data-loading.html#stores) for info about stores), it's best to limit your access to `FlowRouter`. That way the parts of your app with remain modular and more independent. In the case of `FlowRouter`, it's best to access it solely from the top of your component hierarchy, either in the "page" component, or the layouts that wrap it (see below).
+Like any other global singleton in your application (see the [data loading](data-loading.html#stores) for info about stores), it's best to limit your access to `FlowRouter`. That way the parts of your app will remain modular and more independent. In the case of `FlowRouter`, it's best to access it solely from the top of your component hierarchy, either in the "page" component, or the layouts that wrap it (see below).
 
 <h3 id="current-route">The current route</h3>
 
@@ -134,7 +134,7 @@ Template.appBody.helpers({
 
 <h2 id="rendering-routes">Rendering based on the route</h2>
 
-Now we understand how to define routes and access information about the current route, we are in a position to do you usually want to do when a user accesses a route---render a user interface to the screen that represents it.
+Now we understand how to define routes and access information about the current route, we are in a position to do what you usually want to do when a user accesses a route---render a user interface to the screen that represents it.
 
 *In this section, we'll discuss how to render routes using Blaze as the UI engine. If you are building your app with React or Angular, you will end up with similar concepts but the code will not be exactly the same.*
 
@@ -181,7 +181,7 @@ It makes sense for a "page" smart component like `listShowPage` to:
 1. Collect route information,
 2. Subscribe to relevant subscriptions,
 3. Fetch the data from those subscriptions, and
-4. Pass that data into a sub-component
+4. Pass that data into a sub-component.
 
 In this case, the `listShowPage` template simply renders as:
 
@@ -193,7 +193,7 @@ In this case, the `listShowPage` template simply renders as:
 </template>
 ```
 
-(The `{% raw %}{{#each}}{% endraw %}}` is a animation technique that we also discuss in the [UI/UX](ui-ux.html)).
+(The `{% raw %}{{#each}}{% endraw %}}` is an animation technique that we also discuss in the [UI/UX](ui-ux.html)).
 
 It's the `listShow` template (a pure component) that actually handles the job of rendering the content of the page. As the page component is passing the arguments into the pure component, it is able to be quite mechanical and the concerns of talking to the router and rendering the page have been separated.
 
@@ -215,7 +215,7 @@ It's best to keep all logic around what to render in the component hierarchy (i.
 </template>
 ```
 
-Of course, we might start finding that we need to share this functionality between the multiple pages of our app that have access control required. However, we can share functionality between templates---by wrapping them in a wrapper "layout" template which includes the behaviour we want.
+Of course, we might start finding that we need to share this functionality between the multiple pages of our app that have access control required. However, we can share functionality between templates---by wrapping them in a wrapper "layout" template which includes the behavior we want.
 
 You can create wrapper templates by using the "template as block helper" ability of Blaze (see the [Blaze Article](blaze.html)). So we can write an authorization template:
 
@@ -241,9 +241,9 @@ Once that template exists, we can simply wrap our `listsShowPage`:
 </template>
 ```
 
-A chief advantage of this approach is that it is immediately clear when viewing the `listShowPage` what behaviour will occur when a user visits the page.
+A chief advantage of this approach is that it is immediately clear when viewing the `listShowPage` what behavior will occur when a user visits the page.
 
-Multiple behaviours of this type can be composed by wrapping a template in multiple wrappers, or wrapping the wrappers themselves.
+Multiple behaviors of this type can be composed by wrapping a template in multiple wrappers, or wrapping the wrappers themselves.
 
 <h2 id="changing-routes">Changing Routes</h2>
 
@@ -293,7 +293,7 @@ In general if you want to store arbitrary serializable data in a URL param, you 
 FlowRouter.setQueryParams({data: encodeURIComponent(EJSON.stringify(data))});
 ```
 
-You can then get the data back out of Flow Router in the opposite way (note that Flow Router unescapes the dat for you automatically):
+You can then get the data back out of Flow Router in the opposite way (note that Flow Router unescapes the data for you automatically):
 
 ```js
 const data = EJSON.parse(FlowRouter.getQueryParam('data'));
@@ -328,7 +328,7 @@ FlowRouter.route('/', {
 });
 ```
 
-Because the `rootRedirector` template is rendered inside the `appBody` layout which takes care of subscribing to the set of lists the user knows about *before* rendering it's sub-template, and we are guaranteed there is at least one such list, we can simply do:
+Because the `rootRedirector` template is rendered inside the `appBody` layout which takes care of subscribing to the set of lists the user knows about *before* rendering its sub-template, and we are guaranteed there is at least one such list, we can simply do:
 
 ```js
 Template.rootRedirector.onCreated(() => {

--- a/content/security.md
+++ b/content/security.md
@@ -4,22 +4,22 @@ title: "Security"
 
 After reading this guide, you'll know:
 
-1. The security surface area of a Meteor app
-2. How to secure methods, publications, and source code
-3. Where to store secret keys in development and production
-4. How to follow a security checklist when auditing your app
+1. The security surface area of a Meteor app.
+2. How to secure methods, publications, and source code.
+3. Where to store secret keys in development and production.
+4. How to follow a security checklist when auditing your app.
 
 <h1 id="introduction">Introduction</h1>
 
 Securing a web application is all about understanding security domains and understanding the attack surface between these domains. In a Meteor app, things are pretty simple:
 
-1. Code that runs on the server can be trusted
-2. Everything else: code that runs on the client, data sent through method and publication arguments, etc, can't be trusted
+1. Code that runs on the server can be trusted.
+2. Everything else: code that runs on the client, data sent through method and publication arguments, etc, can't be trusted.
 
 In practice, this means that you should do most of your security and validation on the boundary between these two domains. In simple terms:
 
-1. Validate and check all inputs that come from the client
-2. Don't leak any secret information to the client
+1. Validate and check all inputs that come from the client.
+2. Don't leak any secret information to the client.
 
 <h2 id="attack-surface">Concept: Attack surface</h2>
 
@@ -39,7 +39,7 @@ There have been several articles about the potential pitfalls of accepting Mongo
 
 Given the points above, we recommend that all Meteor apps should use Methods to accept data input from the client, and restrict the arguments accepted by each Method as tightly as possible.
 
-Here's a code snippet to disable client-side updates on a collection; this will make sure no other part of the code can use `allow`:
+Here's a code snippet to add to your server code, which disables client-side updates on a collection; this will make sure no other part of the code can use `allow`:
 
 ```js
 // Deny all client-side updates on the Lists collection
@@ -140,7 +140,7 @@ Lists.methods.makePrivate = new Method({
 });
 ```
 
-You can see that this method does a _very spefific thing_ - it just makes a single list private. An alternative would have been to have a method called `setPrivacy`, which could set the list to private or public, but it turns out that in this particular app the security considerations for the two related operations - `makePrivate` and `makePublic` - are very different. By splitting our operations into different methods, we make each one much clearer. It's obvious from the above method definition which arguments we accept, what security checks we perform, and what operations we do on the database.
+You can see that this method does a _very specific thing_ - it just makes a single list private. An alternative would have been to have a method called `setPrivacy`, which could set the list to private or public, but it turns out that in this particular app the security considerations for the two related operations - `makePrivate` and `makePublic` - are very different. By splitting our operations into different methods, we make each one much clearer. It's obvious from the above method definition which arguments we accept, what security checks we perform, and what operations we do on the database.
 
 However, this doesn't mean you can't have any flexibility in your methods. Let's look at an example:
 
@@ -202,10 +202,10 @@ In a server-side-rendered framework like Ruby on Rails, it's sufficient to simpl
 
 All of the points above about methods apply to publications as well:
 
-1. Validate all arguments using `check` or `aldeed:simple-schema`
-1. Never pass the current user ID as an argument
-1. Don't take generic arguments; make sure you know exactly what your publication is getting from the client
-1. Use rate limiting to stop people from spamming you with subscriptions
+1. Validate all arguments using `check` or `aldeed:simple-schema`.
+1. Never pass the current user ID as an argument.
+1. Don't take generic arguments; make sure you know exactly what your publication is getting from the client.
+1. Use rate limiting to stop people from spamming you with subscriptions.
 
 <h3 id="fields">Always restrict fields</h3>
 
@@ -294,9 +294,9 @@ In summary, you should make sure that any options passed from the client to a pu
 
 Publications are not the only place the client gets data from the server. The set of source code files and static assets that are served by your application server could also potentially contain sensitive data:
 
-1. Business logic an attacker could analyze to find weak points
-1. Secret algorithms that a competitor could steal
-1. Secret API keys
+1. Business logic an attacker could analyze to find weak points.
+1. Secret algorithms that a competitor could steal.
+1. Secret API keys.
 
 <h3 id="secret-code">Secret server code</h3>
 
@@ -336,8 +336,8 @@ Secret API keys should never be stored in your source code at all, the next sect
 
 Every app will have some secret API keys or passwords:
 
-1. Your database password
-1. API keys for external APIs
+1. Your database password.
+1. API keys for external APIs.
 
 These should never be stored as part of your app's source code in version control, because developers might copy code around to unexpected places and forget that it contains secret keys. You can keep your keys separately in Dropbox, LastPass, or another service, and then reference them when you need to deploy the app.
 
@@ -417,15 +417,15 @@ You can ensure that any unsecured connection to your app redirects to a secure c
 
 // XXX to be finalized later
 
-1. Remove the `insecure` package
-1. Remove the `autopublish` package
-1. Validate all method and publication arguments, and use `audit-argument-checks` to ensure this
-1. Deny writes to the `profile` field on user documents // XXX link to accounts
-1. Use methods instead of client-side insert/update/remove and allow/deny
-1. Use specific selectors and filter fields in publications
-1. Don't use raw string inclusion in Blaze unless you really know what you are doing
-1. Make sure secret API keys and passwords aren't in your source code
-1. Use package scan as a safety net
-1. Secure the data, not the UI - redirecting away from a client-side route does nothing for security, it's just a nice UX feature
+1. Remove the `insecure` package.
+1. Remove the `autopublish` package.
+1. Validate all method and publication arguments, and use `audit-argument-checks` to ensure this.
+1. Deny writes to the `profile` field on user documents // XXX link to accounts.
+1. Use methods instead of client-side insert/update/remove and allow/deny.
+1. Use specific selectors and filter fields in publications.
+1. Don't use raw string inclusion in Blaze unless you really know what you are doing.
+1. Make sure secret API keys and passwords aren't in your source code.
+1. Use package scan as a safety net.
+1. Secure the data, not the UI - redirecting away from a client-side route does nothing for security, it's just a nice UX feature.
 1. Don't ever trust user IDs passed from the client. Use `this.userId` inside methods and publications.
 1. Set up browser policy, but know that not all browsers support it so it's mostly a convenience/extra layer thing


### PR DESCRIPTION
Mainly typos and consistency, with one small change to clarify where a code snippet should be used.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/meteor/guide/pull/150%23issuecomment-163360090%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/150%23issuecomment-163360090%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Really%20awesome%20edits%20-%20I%27ve%20filed%20a%20separate%20issue%20for%20rewording%20that%20section.%22%2C%20%22created_at%22%3A%20%222015-12-09T19%3A08%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/150#issuecomment-163360090'>General Comment</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Really awesome edits - I've filed a separate issue for rewording that section.


<a href='https://www.codereviewhub.com/meteor/guide/pull/150?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/meteor/guide/pull/150?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/meteor/guide/pull/150'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>