### PR TITLE
Suggestions for data loading chapter

### DIFF
--- a/content/data-loading.md
+++ b/content/data-loading.md
@@ -112,9 +112,11 @@ In this code snippet we can see two important techniques for subscribing in Blaz
 
 Subscribing to data puts it in your client-side collections. To use the data in your templates, you need to query those collections for that data. There are a few important rules of thumb when doing this.
 
-1. Always use the same query to fetch the data from the collection that you use to publish it.
+1. Always use specific queries to fetch data.
 
-  If you don't do this, then you open yourself up to problems if another subscription pushes data into the same collection. Although you may be confident that this is not the case, in an actively developed application, it's impossible to anticipate what may change in the future and this can be a source of hard to understand bugs.
+If you're publishing a subset of your data, it might be tempting to simply query for all data available in a collection (i.e. `Lists.find()`) in order to get that subset on the client, without re-specifying the Mongo selector you used to publish that data in the first place.
+
+  But if you do this, then you open yourself up to problems if another subscription pushes data into the same collection. Although you may be confident that this is not the case, in an actively developed application, it's impossible to anticipate what may change in the future and this can be a source of hard to understand bugs.
 
   Also, when changing subscriptions, there is a brief period where both subscriptions are loaded (see "Publication behavior when changing arguments" below), so when doing thing like pagination, it's exceedingly likely that this will be the case.
 

--- a/content/data-loading.md
+++ b/content/data-loading.md
@@ -92,11 +92,12 @@ What this means in practice is that you should place your subscription calls in 
 
 ```js
 Template.listsShowPage.onCreated(function() {
-  this.state = new ReactiveDict();
-  this.autorun(() => {
+  const template = this;
+  template.state = new ReactiveDict();
+  template.autorun(() => {
     const listId = FlowRouter.getParam('_id');
-    this.state.set({listId});
-    this.subscribe('list/todos', listId);
+    template.state.set({listId});
+    template.subscribe('list/todos', listId);
   });
 });
 ```
@@ -156,10 +157,11 @@ We've seen an example already of using an `autorun` to re-subscribe when the (re
 
 ```js
 Template.listsShowPage.onCreated(function() {
-  this.state = new ReactiveDict();
-  this.autorun(() => {
-    this.state.set('listId', FlowRouter.getParam('_id'));
-    this.subscribe('list/todos', this.state.get('listId'));
+  const template = this;
+  template.state = new ReactiveDict();
+  template.autorun(() => {
+    template.state.set('listId', FlowRouter.getParam('_id'));
+    template.subscribe('list/todos', template.state.get('listId'));
   });
 });
 ```
@@ -223,10 +225,11 @@ Then on the client side, we'd some kind of reactive state variable to control ho
 
 ```js
 Template.listsShowPage.onCreated(function() {
-  this.state = new ReactiveDict();
-  this.autorun(() => {
-    this.state.set('listId', FlowRouter.getParam('_id'));
-    this.subscribe('list/todos', this.state.get('listId'), this.state.get('requestedTodos'));
+  const template = this;
+  template.state = new ReactiveDict();
+  template.autorun(() => {
+    template.state.set('listId', FlowRouter.getParam('_id'));
+    template.subscribe('list/todos', template.state.get('listId'), template.state.get('requestedTodos'));
   });
 });
 ```


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/meteor/guide/pull/161%23issuecomment-165016254%22%2C%20%22https%3A//github.com/meteor/guide/pull/161%23issuecomment-165023637%22%2C%20%22https%3A//github.com/meteor/guide/pull/161%23issuecomment-165025313%22%2C%20%22https%3A//github.com/meteor/guide/pull/161%23issuecomment-165293822%22%2C%20%22https%3A//github.com/meteor/guide/pull/161%23issuecomment-165309691%22%2C%20%22https%3A//github.com/meteor/guide/pull/161%23issuecomment-165346482%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/161%23issuecomment-165016254%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40SachaG%3A%20Thank%20you%20for%20submitting%20a%20pull%20request%21%20%20%20%20%20%20%20%20%20%20%20Before%20we%20can%20merge%20it%2C%20%20%20%20%20%20%20%20%20%20%20you%27ll%20need%20to%20sign%20the%20Meteor%20Contributor%20Agreement%20here%3A%20%20%20%20%20%20%20%20%20%20%20https%3A//contribute.meteor.com/%22%2C%20%22created_at%22%3A%20%222015-12-16T06%3A49%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4250050%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/meteor-bot%22%7D%7D%2C%20%7B%22body%22%3A%20%22What%27s%20wrong%20with%20%60this%60%3F%22%2C%20%22created_at%22%3A%20%222015-12-16T07%3A39%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20thought%20it%20was%20generally%20accepted%20that%20%60this%60%20is%20ambiguous%20and%20should%20be%20avoided%20if%20possible%3F%20I%20especially%20think%20that%20using%20%60this.subscribe%60%20to%20mean%20%60template.subscribe%60%20inside%20an%20Autorun%20is%20bad%20practice%2C%20since%20some%20functions%20can%20change%20the%20value%20of%20%60this%60.%20%22%2C%20%22created_at%22%3A%20%222015-12-16T07%3A50%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/358832%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/SachaG%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27m%20not%20sure.%20In%20ES6%20land%2C%20%60this%60%20is%20a%20lot%20more%20reliable%20%28i.e.%20if%20you%20use%20%60%3D%3E%60%20you%20are%20in%20control%20of%20what%20%60this%60%20is%29.%5Cr%5Cn%5Cr%5CnPS%20we%20adopted%20a%20convention%20of%20%60const%20instance%20%3D%20Template.instance%28%29%60%20%28rather%20than%20the%20old%20%60template%60%29%20for%20better%20or%20for%20worse.%22%2C%20%22created_at%22%3A%20%222015-12-16T23%3A57%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22Oh%20ok%2C%20I%20hadn%27t%20thought%20about%20the%20ES6%20thing.%20I%20still%20think%20using%20%60instance%60%20is%20a%20lot%20better%20for%20code%20readability%2C%20but%20it%27s%20not%20a%20huge%20deal.%20%22%2C%20%22created_at%22%3A%20%222015-12-17T01%3A35%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/358832%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/SachaG%22%7D%7D%2C%20%7B%22body%22%3A%20%22Can%20you%20send%20a%20new%20PR%20with%20just%20the%20text%20changes%20%40SachaG%3F%22%2C%20%22created_at%22%3A%20%222015-12-17T05%3A45%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/161#issuecomment-165016254'>General Comment</a></b>
- <a href='https://github.com/meteor-bot'><img border=0 src='https://avatars.githubusercontent.com/u/4250050?v=3' height=16 width=16'></a> @SachaG: Thank you for submitting a pull request!           Before we can merge it,           you'll need to sign the Meteor Contributor Agreement here:           https://contribute.meteor.com/
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> What's wrong with `this`?
- <a href='https://github.com/SachaG'><img border=0 src='https://avatars.githubusercontent.com/u/358832?v=3' height=16 width=16'></a> I thought it was generally accepted that `this` is ambiguous and should be avoided if possible? I especially think that using `this.subscribe` to mean `template.subscribe` inside an Autorun is bad practice, since some functions can change the value of `this`.
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> I'm not sure. In ES6 land, `this` is a lot more reliable (i.e. if you use `=>` you are in control of what `this` is).
PS we adopted a convention of `const instance = Template.instance()` (rather than the old `template`) for better or for worse.
- <a href='https://github.com/SachaG'><img border=0 src='https://avatars.githubusercontent.com/u/358832?v=3' height=16 width=16'></a> Oh ok, I hadn't thought about the ES6 thing. I still think using `instance` is a lot better for code readability, but it's not a huge deal.
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> Can you send a new PR with just the text changes @SachaG?


<a href='https://www.codereviewhub.com/meteor/guide/pull/161?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/meteor/guide/pull/161?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/meteor/guide/pull/161'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>