### PR TITLE
Migrations are defined in server-side code

### DIFF
--- a/content/collections.md
+++ b/content/collections.md
@@ -311,7 +311,9 @@ As we discussed above, trying to predict all future requirements of your data sc
 
 <h3 id="writing-migrations">Writing migrations</h3>
 
-A useful package for writing migrations is [`percolate:migrations`](https://atmospherejs.com/percolate/migrations), which provides a nice framework for switching between different versions of your schema. Suppose, as an example, that we wanted to add a `list.todoCount` field, and ensure that it was set for all existing lists. Then we might write:
+A useful package for writing migrations is [`percolate:migrations`](https://atmospherejs.com/percolate/migrations), which provides a nice framework for switching between different versions of your schema. 
+
+Suppose, as an example, that we wanted to add a `list.todoCount` field, and ensure that it was set for all existing lists. Then we might write the following in server-only code (e.g. `/server/migrations.js`):
 
 ```js
 Migrations.add({


### PR DESCRIPTION
The `percolate:migrations` documention mentions the following:

> write a simple migration, somewhere in the server section of your project

So, I am adding the note to the migrations section as well.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/meteor/guide/pull/179?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/meteor/guide/pull/179'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>