### PR TITLE
Typos & Grammatical Changes

### DIFF
--- a/content/routing.md
+++ b/content/routing.md
@@ -409,7 +409,7 @@ Template.App_body.events({
 });
 ```
 
-You will also want to show some kind of status while the method is working so that the user knows there is something going on between them clicking the button and the redirect happening (and show the error some kind of message if the method is returning an error too).
+You will also want to show some kind of indication that the method is working in between their click of the button and the redirect completing.  Don't forget to provide feedback if the method is returning an error.
 
 <h2 id="advanced">Advanced Routing</h2>
 


### PR DESCRIPTION
The really long paragraph was phrased in a way which did not read naturally and the parenthetical notation had some extraneous words and a missing comma.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/meteor/guide/pull/203%23issuecomment-173473573%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/203%23issuecomment-173473573%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Makes%20sense%20to%20me%2C%20thanks%21%22%2C%20%22created_at%22%3A%20%222016-01-21T06%3A30%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/203#issuecomment-173473573'>General Comment</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Makes sense to me, thanks!


<a href='https://www.codereviewhub.com/meteor/guide/pull/203?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/meteor/guide/pull/203?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/meteor/guide/pull/203'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>