### PR TITLE
Fix name of this.changed in Meteor.publish example

### DIFF
--- a/content/data-loading.md
+++ b/content/data-loading.md
@@ -480,7 +480,7 @@ Meteor.publishComposite('Todos.admin.inList', function(listId) {
 
 In all of our examples so far (outside of using`Meteor.publishComposite()`) we've returned a cursor from our `Meteor.publish()` handlers. Doing this ensures Meteor takes care of the job of keeping the contents of that cursor in sync between the server and the client. However, there's another API you can use for publish functions which is closer to the way the underlying Distributed Data Protocol (DDP) works.
 
-DDP uses three main messages to communicate changes in the data for a publication: the `added`, `updated` and `removed` messages. So, we can similarly do the same for a publication:
+DDP uses three main messages to communicate changes in the data for a publication: the `added`, `changed` and `removed` messages. So, we can similarly do the same for a publication:
 
 ```js
 Meteor.publish('custom-publication', function() {
@@ -493,7 +493,7 @@ Meteor.publish('custom-publication', function() {
   // We may respond to some 3rd party event and want to send notifications
   Meteor.setTimeout(() => {
     // If we want to modify a document that we've already added
-    this.updated('collection-name', 'id', {field: 'new-value'});
+    this.changed('collection-name', 'id', {field: 'new-value'});
 
     // Or if we don't want the client to see it any more
     this.removed('collection-name', 'id');
@@ -578,7 +578,7 @@ Meteor.publish('polled-publication', function() {
 
     data.forEach((doc) => {
       if (publishedKeys[doc._id]) {
-        this.updated(COLLECTION_NAME, doc._id, doc);
+        this.changed(COLLECTION_NAME, doc._id, doc);
       } else {
         publishedKeys[doc._id] = true;
         if (publishedKeys[doc._id]) {


### PR DESCRIPTION
`this.updated` isn't a real method: http://docs.meteor.com/#/full/publish_changed
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/meteor/guide/pull/213%23issuecomment-175158312%22%2C%20%22https%3A//github.com/meteor/guide/pull/213%23issuecomment-175180938%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/213%23issuecomment-175158312%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40wuservices%3A%20Thank%20you%20for%20submitting%20a%20pull%20request%21%20%20%20%20%20%20%20%20%20%20%20Before%20we%20can%20merge%20it%2C%20%20%20%20%20%20%20%20%20%20%20you%27ll%20need%20to%20sign%20the%20Meteor%20Contributor%20Agreement%20here%3A%20%20%20%20%20%20%20%20%20%20%20https%3A//contribute.meteor.com/%22%2C%20%22created_at%22%3A%20%222016-01-26T18%3A23%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4250050%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/meteor-bot%22%7D%7D%2C%20%7B%22body%22%3A%20%22Good%20catch%21%20Thanks%22%2C%20%22created_at%22%3A%20%222016-01-26T19%3A04%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/213#issuecomment-175158312'>General Comment</a></b>
- <a href='https://github.com/meteor-bot'><img border=0 src='https://avatars.githubusercontent.com/u/4250050?v=3' height=16 width=16'></a> @wuservices: Thank you for submitting a pull request!           Before we can merge it,           you'll need to sign the Meteor Contributor Agreement here:           https://contribute.meteor.com/
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Good catch! Thanks


<a href='https://www.codereviewhub.com/meteor/guide/pull/213?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/meteor/guide/pull/213?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/meteor/guide/pull/213'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>