### PR TITLE
Update methods.md - this datacontext different?

### DIFF
--- a/content/methods.md
+++ b/content/methods.md
@@ -332,8 +332,10 @@ Template.Invoices_newInvoice.onCreated(function() {
 });
 
 Template.Invoices_newInvoice.helpers({
+  
   errors(fieldName) {
-    return this.errors.get(fieldName);
+    const instance = Template.instance();
+    return instance.errors.get(fieldName);
   }
 });
 


### PR DESCRIPTION
I was working through my own version of this code and found that this.errors was undefined in the .helpers method because this refers to a different object to what it did during onCreated (where it referred to the template instance).  Changing the code to explicitly reference the instance should stop that?
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/meteor/guide/pull/214%23issuecomment-176041481%22%2C%20%22https%3A//github.com/meteor/guide/pull/214%23issuecomment-176067117%22%2C%20%22https%3A//github.com/meteor/guide/pull/214%23issuecomment-176083028%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/214%23issuecomment-176041481%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40tomRedox%3A%20Thank%20you%20for%20submitting%20a%20pull%20request%21%20%20%20%20%20%20%20%20%20%20%20Before%20we%20can%20merge%20it%2C%20%20%20%20%20%20%20%20%20%20%20you%27ll%20need%20to%20sign%20the%20Meteor%20Contributor%20Agreement%20here%3A%20%20%20%20%20%20%20%20%20%20%20https%3A//contribute.meteor.com/%22%2C%20%22created_at%22%3A%20%222016-01-28T07%3A55%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4250050%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/meteor-bot%22%7D%7D%2C%20%7B%22body%22%3A%20%22You%27re%20right%21%20Thanks%20%3A%29%22%2C%20%22created_at%22%3A%20%222016-01-28T08%3A54%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20was%20just%20listening%20to%20Abhi%20on%20%5BMeteor%20Interviews%20episode%2012%5D%28http%3A//www.meteorinterviews.com/12%29%20and%20he%20was%20saying%20%5C%22%27this%27%20is%20the%20root%20of%20evil%20in%20Blaze%20templates%5C%22%20which%20I%20am%20rapidly%20coming%20to%20agree%20with.%20%20I%20wonder%20if%20it%20would%20be%20worth%20avoiding%20this%20altogether%20in%20Blaze%20best%20practice%20examples%20and%20instead%20making%20it%20explicit%20what%20is%20being%20referred%20to%3F%20%20Might%20make%20a%20better%20learning%20resource%3F%22%2C%20%22created_at%22%3A%20%222016-01-28T09%3A34%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11335350%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tomRedox%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/214#issuecomment-176041481'>General Comment</a></b>
- <a href='https://github.com/meteor-bot'><img border=0 src='https://avatars.githubusercontent.com/u/4250050?v=3' height=16 width=16'></a> @tomRedox: Thank you for submitting a pull request!           Before we can merge it,           you'll need to sign the Meteor Contributor Agreement here:           https://contribute.meteor.com/
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> You're right! Thanks :)
- <a href='https://github.com/tomRedox'><img border=0 src='https://avatars.githubusercontent.com/u/11335350?v=3' height=16 width=16'></a> I was just listening to Abhi on [Meteor Interviews episode 12](http://www.meteorinterviews.com/12) and he was saying "'this' is the root of evil in Blaze templates" which I am rapidly coming to agree with.  I wonder if it would be worth avoiding this altogether in Blaze best practice examples and instead making it explicit what is being referred to?  Might make a better learning resource?


<a href='https://www.codereviewhub.com/meteor/guide/pull/214?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/meteor/guide/pull/214?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/meteor/guide/pull/214'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>