### PR TITLE
Rename `instance` to `tmpl`

### DIFF
--- a/content/ui-ux.md
+++ b/content/ui-ux.md
@@ -88,14 +88,14 @@ Template.Lists_show_page.helpers({
   // removed and a new copy is added when changing lists, which is
   // important for animation purposes.
   listIdArray() {
-    const instance = Template.instance();
-    const listId = instance.getListId();
+    const tmpl = Template.instance();
+    const listId = tmpl.getListId();
     return Lists.findOne(listId) ? [listId] : [];
   },
   listArgs(listId) {
-    const instance = Template.instance();
+    const tmpl = Template.instance();
     return {
-      todosReady: instance.subscriptionsReady(),
+      todosReady: tmpl.subscriptionsReady(),
       // We pass `list` (which contains the full list, with all fields, as a function
       // because we want to control reactivity. When you check a todo item, the
       // `list.incompleteCount` changes. If we didn't do this the entire list would
@@ -321,16 +321,16 @@ Template.Lists_show_page.onCreated(function() {
 
 Template.Lists_show_page.helpers({
   listArgs(listId) {
-    const instance = Template.instance();
+    const tmpl = Template.instance();
     const list = Lists.findOne(listId);
-    const requested = instance.state.get('requested');
+    const requested = tmpl.state.get('requested');
     return {
       list,
       todos: list.todos({}, {limit: requested}),
       requested,
-      countReady: instance.countSub.ready(),
+      countReady: tmpl.countSub.ready(),
       count: Counts.get(`list/todoCount${listId}`),
-      onNextPage: instance.onNextPage
+      onNextPage: tmpl.onNextPage
     };
   }
 });
@@ -355,8 +355,8 @@ Template.Lists_show_page.onCreated(function() {
   this.visibleTodos = new Mongo.Collection();
 
   this.getTodos = () => {
-    const list = Lists.findOne(this.this.getListId());
-    return list.todos({}, {limit: instance.state.get('requested')});
+    const list = Lists.findOne(this.getListId());
+    return list.todos({}, {limit: this.state.get('requested')});
   };
   // When the user requests it, we should sync the visible todos to reflect the true state of the world
   this.syncTodos = (todos) => {
@@ -382,21 +382,21 @@ Template.Lists_show_page.onCreated(function() {
 
 Template.Lists_show_page.helpers({
   listArgs(listId) {
-    const instance = Template.instance();
+    const tmpl = Template.instance();
     const list = Lists.findOne(listId);
-    const requested = instance.state.get('requested');
+    const requested = tmpl.state.get('requested');
     return {
       list,
       // we pass the *visible* todos through here
-      todos: instance.visibleTodos.find({}, {limit: requested}),
+      todos: tmpl.visibleTodos.find({}, {limit: requested}),
       requested,
-      countReady: instance.countSub.ready(),
+      countReady: tmpl.countSub.ready(),
       count: Counts.get(`list/todoCount${listId}`),
-      onNextPage: instance.onNextPage,
+      onNextPage: tmpl.onNextPage,
       // These two properties allow the user to know that there are changes to be viewed
       // and allow them to view them
-      hasChanges: instance.state.get('hasChanges'),
-      onShowChanges:instance.onShowChanges
+      hasChanges: tmpl.state.get('hasChanges'),
+      onShowChanges: tmpl.onShowChanges
     };
   }
 });
@@ -482,7 +482,7 @@ A good example of this is the editing state of the list from the Todos example a
 
 ```html
 {{#momentum plugin="fade"}}
-  {{#if instance.state.get 'editing'}}
+  {{#if tmpl.state.get 'editing'}}
     <form class="js-edit-form list-edit-form">...</form>
   {{else}}
     <div class="nav-group">...</div>
@@ -545,8 +545,8 @@ Template.Lists_show_page.helpers({
   // removed and a new copy is added when changing lists, which is
   // important for animation purposes.
   listIdArray() {
-    const instance = Template.instance();
-    const listId = instance.getListId();
+    const tmpl = Template.instance();
+    const listId = tmpl.getListId();
     return Lists.findOne(listId) ? [listId] : [];
   }
 });


### PR DESCRIPTION
This is something that has bugged me for a while in various Meteor tutorials available online. Now that we're working in an open forum of best practices I'd like to put forward the case that, in short, naming a variable `instance` is just as non-expressive as declaring one called "variable" (`var variable = xyz`).

The fact that it comes from `Template.instance()` is no reason to call it `instance` – an equivalent (and equivalently) poor case would be `var instance = new TodoItem()`. So, in the same way that we declare `var todoItem = new TodoItem()`, which is considered good practice in both the JavaScript world and beyond, the instance of a Template should be called `template`, or, in short-hand `tmpl`. By lucky coincidence, this abbreviation is as concise (with the same number of letters) as `this`, which it (in many cases) represents.

This change encourages good naming practices for newcomers to Javascript, and improves readability and clarity for more advanced developers who are new to Meteor.

-----

I also fixed a double "this.this" which is invalid Javascript.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/meteor/guide/pull/216%23issuecomment-178060388%22%2C%20%22https%3A//github.com/meteor/guide/pull/216%23issuecomment-178061940%22%2C%20%22https%3A//github.com/meteor/guide/pull/216%23issuecomment-178109181%22%2C%20%22https%3A//github.com/meteor/guide/pull/216%23issuecomment-178123749%22%2C%20%22https%3A//github.com/meteor/guide/pull/216%23issuecomment-178127988%22%2C%20%22https%3A//github.com/meteor/guide/pull/216%23issuecomment-178247759%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/216%23issuecomment-178060388%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40ephemer%3A%20Thank%20you%20for%20submitting%20a%20pull%20request%21%20%20%20%20%20%20%20%20%20%20%20Before%20we%20can%20merge%20it%2C%20%20%20%20%20%20%20%20%20%20%20you%27ll%20need%20to%20sign%20the%20Meteor%20Contributor%20Agreement%20here%3A%20%20%20%20%20%20%20%20%20%20%20https%3A//contribute.meteor.com/%22%2C%20%22created_at%22%3A%20%222016-02-01T16%3A38%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4250050%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/meteor-bot%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20am%20aware%20this%20change%20involves%20more%20than%20just%20the%20one%20page%20I%20edited.%20If%20the%20logic%20makes%20sense%20to%20you%20I%20will%20update%20the%20pull-request%20with%20the%20relevant%20changes%20across%20the%20board%22%2C%20%22created_at%22%3A%20%222016-02-01T16%3A43%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5485935%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ephemer%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20don%27t%20think%20a%20PR%20is%20the%20right%20way%20to%20open%20this%20discussion%20-%20it%20would%20have%20been%20better%20to%20file%20an%20issue.%5Cr%5Cn%5Cr%5CnIn%20truth%2C%20I%20wish%20that%20instead%20of%20Template.instance%28%29%2C%20Blaze%20just%20used%20%60this%60%2C%20but%20it%20doesn%27t.%20%60instance%60%20is%20akin%20to%20%60self%60%20-%20something%20that%20means%20%60this%60%20while%20not%20technically%20using%20the%20%60this%60%20keyword.%20I%20don%27t%20think%20%60tmpl%60%20is%20a%20good%20name%20for%20it%20because%20we%20are%20intentionally%20trying%20to%20differentiate%20between%20a%20_Template_%2C%20which%20is%20a%20template%20definition%2C%20and%20a%20_Template%20Instance_%2C%20which%20is%20a%20particular%20rendered%20view%20on%20the%20page.%5Cr%5Cn%5Cr%5CnI%20don%27t%20think%20the%20variable%20name%20%60tmpl%60%20makes%20that%20distinction%20properly.%20Perhaps%20%60self%60%20would%20be%20better%2C%20but%20that%27s%20no%20better%20than%20%60instance%60.%5Cr%5Cn%5Cr%5CnInstance%20works%20for%20me%20because%20it%20is%20just%20a%20shorthand%20to%20avoid%20typing%20%60Template.instance%28%29%60%20everywhere.%20%40tmeasday%20what%20do%20you%20think%3F%22%2C%20%22created_at%22%3A%20%222016-02-01T18%3A22%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22We%20are%20differentiating%20between%20a%20Template%20%28the%20constructor%20function%29%20and%5Cntemplate%20aka.%20tmpl%2C%20i.e.%20the%20instance%20of%20that%20constructor%20%28or%20class%2C%20in%5CnES2015%29.%5Cn%5CnIf%20you%20prefer%20I%27ll%20put%20this%20on%20the%20meteor%20forum%20or%20something%20for%5Cndiscussion%2C%20I%20agree%20the%20visibility%20of%20PRs%20isn%27t%20particularly%20high.%5CnSashko%20Stubailo%20%3Cnotifications%40github.com%3E%20schrieb%20am%20Mo.%2C%201.%20Feb.%202016%20um%5Cn19%3A22%3A%5Cn%5Cn%3E%20I%20don%27t%20think%20a%20PR%20is%20the%20right%20way%20to%20open%20this%20discussion%20-%20it%20would%5Cn%3E%20have%20been%20better%20to%20file%20an%20issue.%5Cn%3E%5Cn%3E%20In%20truth%2C%20I%20wish%20that%20instead%20of%20Template.instance%28%29%2C%20Blaze%20just%20used%20this%2C%5Cn%3E%20but%20it%20doesn%27t.%20instance%20is%20akin%20to%20self%20-%20something%20that%20means%20this%5Cn%3E%20while%20not%20technically%20using%20the%20this%20keyword.%20I%20don%27t%20think%20tmpl%20is%20a%5Cn%3E%20good%20name%20for%20it%20because%20we%20are%20intentionally%20trying%20to%20differentiate%5Cn%3E%20between%20a%20%2ATemplate%2A%2C%20which%20is%20a%20template%20definition%2C%20and%20a%20%2ATemplate%5Cn%3E%20Instance%2A%2C%20which%20is%20a%20particular%20rendered%20view%20on%20the%20page.%5Cn%3E%5Cn%3E%20I%20don%27t%20think%20the%20variable%20name%20tmpl%20makes%20that%20distinction%20properly.%5Cn%3E%20Perhaps%20self%20would%20be%20better%2C%20but%20that%27s%20no%20better%20than%20instance.%5Cn%3E%5Cn%3E%20Instance%20works%20for%20me%20because%20it%20is%20just%20a%20shorthand%20to%20avoid%20typing%5Cn%3E%20Template.instance%28%29%20everywhere.%20%40tmeasday%20%3Chttps%3A//github.com/tmeasday%3E%5Cn%3E%20what%20do%20you%20think%3F%5Cn%3E%5Cn%3E%20%5Cu2014%5Cn%3E%20Reply%20to%20this%20email%20directly%20or%20view%20it%20on%20GitHub%5Cn%3E%20%3Chttps%3A//github.com/meteor/guide/pull/216%23issuecomment-178109181%3E.%5Cn%3E%5Cn%22%2C%20%22created_at%22%3A%20%222016-02-01T18%3A47%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5485935%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ephemer%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3E%20If%20you%20prefer%20I%27ll%20put%20this%20on%20the%20meteor%20forum%20or%20something%20for%20discussion%2C%20I%20agree%20the%20visibility%20of%20PRs%20isn%27t%20particularly%20high.%5Cr%5Cn%5Cr%5CnThat%20would%20be%20much%20better%2C%20thanks%21%20you%20can%20link%20to%20the%20PR%20if%20you%20feel%20that%20is%20best.%22%2C%20%22created_at%22%3A%20%222016-02-01T18%3A54%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20think%20%40stubailo%20has%20expressed%20the%20reason%20we%20didn%27t%20go%20with%20%60template%60%20%28I%20don%27t%20really%20like%20abbreviating%20things%2C%20so%20I%27d%20vote%20against%20%60tmpl%60%2C%20it%20seems%20like%20a%20relic%20of%20an%20old%20age%20where%20people%20had%20small%20screens%20or%20something%29.%5Cr%5Cn%5Cr%5CnIt%27s%20a%20good%20point%20that%20%60instance%60%20is%20generic%20across%20lots%20of%20types%20of%20classes%20of%20course.%20Perhaps%20Blaze%20should%20have%20come%20up%20with%20a%20better%20name%2C%20but%20I%27d%20probably%20still%20argue%20that%20we%20should%20stick%20with%20the%20name%20that%20Blaze%20uses.%5Cr%5Cn%5Cr%5CnFor%20the%20record%20in%20React%20these%20things%20are%20classed%20%5C%22Component%20Classes%5C%22%20and%20%5C%22Components%5C%22.%22%2C%20%22created_at%22%3A%20%222016-02-01T23%3A08%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/216#issuecomment-178060388'>General Comment</a></b>
- <a href='https://github.com/meteor-bot'><img border=0 src='https://avatars.githubusercontent.com/u/4250050?v=3' height=16 width=16'></a> @ephemer: Thank you for submitting a pull request!           Before we can merge it,           you'll need to sign the Meteor Contributor Agreement here:           https://contribute.meteor.com/
- <a href='https://github.com/ephemer'><img border=0 src='https://avatars.githubusercontent.com/u/5485935?v=3' height=16 width=16'></a> I am aware this change involves more than just the one page I edited. If the logic makes sense to you I will update the pull-request with the relevant changes across the board
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> I don't think a PR is the right way to open this discussion - it would have been better to file an issue.
In truth, I wish that instead of Template.instance(), Blaze just used `this`, but it doesn't. `instance` is akin to `self` - something that means `this` while not technically using the `this` keyword. I don't think `tmpl` is a good name for it because we are intentionally trying to differentiate between a _Template_, which is a template definition, and a _Template Instance_, which is a particular rendered view on the page.
I don't think the variable name `tmpl` makes that distinction properly. Perhaps `self` would be better, but that's no better than `instance`.
Instance works for me because it is just a shorthand to avoid typing `Template.instance()` everywhere. @tmeasday what do you think?
- <a href='https://github.com/ephemer'><img border=0 src='https://avatars.githubusercontent.com/u/5485935?v=3' height=16 width=16'></a> We are differentiating between a Template (the constructor function) and
template aka. tmpl, i.e. the instance of that constructor (or class, in
ES2015).
If you prefer I'll put this on the meteor forum or something for
discussion, I agree the visibility of PRs isn't particularly high.
Sashko Stubailo <notifications@github.com> schrieb am Mo., 1. Feb. 2016 um
19:22:
> I don't think a PR is the right way to open this discussion - it would
> have been better to file an issue.
>
> In truth, I wish that instead of Template.instance(), Blaze just used this,
> but it doesn't. instance is akin to self - something that means this
> while not technically using the this keyword. I don't think tmpl is a
> good name for it because we are intentionally trying to differentiate
> between a *Template*, which is a template definition, and a *Template
> Instance*, which is a particular rendered view on the page.
>
> I don't think the variable name tmpl makes that distinction properly.
> Perhaps self would be better, but that's no better than instance.
>
> Instance works for me because it is just a shorthand to avoid typing
> Template.instance() everywhere. @tmeasday <https://github.com/tmeasday>
> what do you think?
>
> —
> Reply to this email directly or view it on GitHub
> <https://github.com/meteor/guide/pull/216#issuecomment-178109181>.
>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> > If you prefer I'll put this on the meteor forum or something for discussion, I agree the visibility of PRs isn't particularly high.
That would be much better, thanks! you can link to the PR if you feel that is best.
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> I think @stubailo has expressed the reason we didn't go with `template` (I don't really like abbreviating things, so I'd vote against `tmpl`, it seems like a relic of an old age where people had small screens or something).
It's a good point that `instance` is generic across lots of types of classes of course. Perhaps Blaze should have come up with a better name, but I'd probably still argue that we should stick with the name that Blaze uses.
For the record in React these things are classed "Component Classes" and "Components".


<a href='https://www.codereviewhub.com/meteor/guide/pull/216?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/meteor/guide/pull/216?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/meteor/guide/pull/216'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>