### PR TITLE
Change the mquandalle:jade recommendation to dalgard:jade

### DIFF
--- a/content/build-tool.md
+++ b/content/build-tool.md
@@ -219,7 +219,7 @@ The aptly named `blaze-html-templates` package that comes with every new Meteor 
 
 <h3 id="blaze-jade">Blaze Jade templates</h3>
 
-If you don't like the Spacebars syntax Meteor uses by default and want something more concise, you can give Jade a try by using [`mquandalle:jade`](https://atmospherejs.com/mquandalle/jade). This package will compile all files in your app with the `.jade` extension into Blaze-compatible code, and can be used side-by-side with `blaze-html-templates` if you want to have some of your code in Spacebars and some in Jade.
+If you don't like the Spacebars syntax Meteor uses by default and want something more concise, you can give Jade a try by using [`dalgard:jade`](https://atmospherejs.com/dalgard/jade). This package will compile all files in your app with the `.jade` extension into Blaze-compatible code, and can be used side-by-side with `blaze-html-templates` if you want to have some of your code in Spacebars and some in Jade.
 
 <h3 id="react-jsx">JSX for React</h3>
 


### PR DESCRIPTION
I suggest changing the recommendation for Jade package from mquandalle:jade to dalgard:jade. The reason is that dalgard:jade is more up to date with new Blaze features (like the ones in Meteor 1.2) and it's used for many projects such as manuel:viewmodel because of its shorter syntax.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/meteor/guide/pull/217%23issuecomment-178396529%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/217%23issuecomment-178396529%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Looks%20good%21%22%2C%20%22created_at%22%3A%20%222016-02-02T06%3A19%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/217#issuecomment-178396529'>General Comment</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Looks good!


<a href='https://www.codereviewhub.com/meteor/guide/pull/217?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/meteor/guide/pull/217?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/meteor/guide/pull/217'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>