### PR TITLE
Adjusted scope DOM lookups section to clarify onRendered approach.

### DIFF
--- a/content/blaze.md
+++ b/content/blaze.md
@@ -376,7 +376,7 @@ Template.Lists_show.events({
 
 It's a bad idea to look up things directly in the DOM with jQuery's global `$()`. It's easy to select some element on the page that has nothing to do with the current component. Also, it limits your options on rendering *outside* of the main document (see testing section below).
 
-Instead, Blaze gives you `instance.$()` which scopes a lookup to within the current template instance. Typically you use this either from a `onRendered()` callback to setup jQuery plugins, or from event handlers to call DOM functions directly. For instance, when the user clicks the add todo button, we want to focus the `<input>` element:
+Instead, Blaze gives you a way to scope a lookup to within the current template instance. Typically you use this either from a `onRendered()` callback to setup jQuery plugins (called via `Template.instance().$()` or `this.$()`), or from event handlers to call DOM functions directly (called via `Template.instance().$()` or using the event handlers second argument like `instance.$()`). For instance, when the user clicks the add todo button, we want to focus the `<input>` element:
 
 ```js
 Template.Lists_show.events({


### PR DESCRIPTION
Hi guys - the "Scope DOM lookups to the template instance" section mentions "Instead, Blaze gives you `instance.$()` which scopes a lookup to within the current template instance. ". Newcomers might assume `instance.$()` is also available within the lifecycle callbacks as well. It might be worth clarifying this a bit. I've taken a crack at it. Thanks!
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/meteor/guide/pull/224%23issuecomment-181118412%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/224%23issuecomment-181118412%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Good%20idea%2C%20thanks%20%40hwillson%21%22%2C%20%22created_at%22%3A%20%222016-02-07T21%3A12%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/224#issuecomment-181118412'>General Comment</a></b>
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> Good idea, thanks @hwillson!


<a href='https://www.codereviewhub.com/meteor/guide/pull/224?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/meteor/guide/pull/224?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/meteor/guide/pull/224'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>