### PR TITLE
Updates to the build article content for 1.3

### DIFF
--- a/content/build-tool.md
+++ b/content/build-tool.md
@@ -79,7 +79,7 @@ One difference between pre-published packages and local app packages is that the
 
 <h4 id="npm-adding">Adding packages to your app</h4>
 
-To install an NPM package into your app, you can simply run NPM's standard install command:
+To install an NPM package into your app, you can simply run NPM's (we recommend using NPM3, although other versions of NPM should work with Meteor also) standard install command:
 
 ```
 npm install --save <package name>

--- a/content/build-tool.md
+++ b/content/build-tool.md
@@ -79,7 +79,16 @@ One difference between pre-published packages and local app packages is that the
 
 <h4 id="npm-adding">Adding packages to your app</h4>
 
-Meteor 1.3 will have seamless integration with NPM, and you will be able to simply `npm install` these packages into your app directory. Until then, the easiest way to use NPM packages in your app is [`meteorhacks:npm`](https://atmospherejs.com/meteorhacks/npm).
+To install an NPM package into your app, you can simply run NPM's standard install command:
+
+```
+npm install --save-dev <package name>
+```
+
+XXX: Is it `meteor npm`
+XXX: Do we use --save-dev
+XXX: What about creating an initial `package.json`
+XXX: How do other developers get the packages?
 
 <h4 id="npm-searching">Searching for packages</h4>
 
@@ -175,7 +184,10 @@ sendTextMessage() {
 
 <h3 id="client-npm">NPM on the client</h3>
 
-NPM started as a package manager for Node.js, but is quickly becoming one of the most popular places to publish client-side modules as well. Meteor 1.3 will include built-in support for bundling NPM modules on the client, but in the meantime the best option is to use the [`cosmos:browserify`](https://atmospherejs.com/cosmos/browserify) package to bundle these modules. Since one of the most common scenarios is using React components from NPM, read about how to do this in the [React in Meteor guide](http://react-in-meteor.readthedocs.org/en/latest/client-npm/).
+NPM started as a package manager for Node.js, but is quickly becoming one of the most popular places to publish client-side modules as well. Thanks to Meteor's built in client-side support for [ES2015 modules](app-structure.html#modules), you can use appropriate NPM packages on the client easily, simply by installing the package as usual and `import`-ing from it from a client-side file.
+
+For example, in the [React article](react.html#react-router) we discuss how to use the [React Router](https://github.com/rackt/react-router) in the client side of an app with a few simple commands.
+
 
 <h2 id="javascript-transpilation">JavaScript transpilation</h2>
 
@@ -302,7 +314,33 @@ Currently, Meteor doesn't have a separate build step for post-processing CSS, so
 
 <h3 id="juliancwirko-postcss">juliancwirko:postcss</h3>
 
-Use the package [juliancwirko:postcss](https://atmospherejs.com/juliancwirko/postcss) to your app to enable PostCSS for your Meteor app. It's not completely trivial to set it up, and we hope to make support for PostCSS a more core part of Meteor in the future. Read the documentation for the package to get the steps to add it to your app; we won't reproduce the instructions here since they might change in future versions.
+Use the package [juliancwirko:postcss](https://atmospherejs.com/juliancwirko/postcss) to your app to enable PostCSS for your Meteor app. To do so, we remove the standard CSS minifier and replace it with the postcss package:
+
+```
+meteor remove standard-minifiers
+meteor add juliancwirko:postcss
+# We still want Meteor's built in JS minifiers
+meteor add standard-minifiers-js
+```
+
+Then we can install any NPM CSS processing packages that we'd like to use and reference them from a `postcss` section of our `package.json`. In the Todos example app, we use `autoprefixer` package to increase browser support:
+
+```
+{
+  "devDependencies": {
+    "autoprefixer": "^6.3.1"
+  },
+  "postcss": {
+    "plugins": {
+      "autoprefixer": {"browsers": ["last 2 versions"]}
+    }
+  }
+}
+```
+
+After doing the above, you'll need to ensure you `npm install` and restart the `meteor` process running your app to make sure the PostCSS system has had a chance to set itself up.
+
+XXX: ensure the 1.3 version of this package has been release before publishing this?
 
 <h2 id="minification">Minification</h2>
 

--- a/content/build-tool.md
+++ b/content/build-tool.md
@@ -82,13 +82,12 @@ One difference between pre-published packages and local app packages is that the
 To install an NPM package into your app, you can simply run NPM's standard install command:
 
 ```
-npm install --save-dev <package name>
+npm install --save <package name>
 ```
 
-XXX: Is it `meteor npm`
-XXX: Do we use --save-dev
-XXX: What about creating an initial `package.json`
-XXX: How do other developers get the packages?
+If the package is just a development dependency (i.e. it's used for testing, linting or the like), then you can use `--save-dev`. That way if you have some kind of build script, it can do `npm install --production` and avoid installing packages it doesn't need.
+
+Note that your colleagues will need to run `npm install` when they update their version of the app to get the NPM dependency. The Meteor tool will warn them if they fail to do so.
 
 <h4 id="npm-searching">Searching for packages</h4>
 
@@ -339,8 +338,6 @@ Then we can install any NPM CSS processing packages that we'd like to use and re
 ```
 
 After doing the above, you'll need to ensure you `npm install` and restart the `meteor` process running your app to make sure the PostCSS system has had a chance to set itself up.
-
-XXX: ensure the 1.3 version of this package has been release before publishing this?
 
 <h2 id="minification">Minification</h2>
 


### PR DESCRIPTION
Still some unanswered questions but I'm interested in your thoughts @stubailo
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/meteor/guide/pull/225%23discussion_r52136184%22%2C%20%22https%3A//github.com/meteor/guide/pull/225%23discussion_r52136224%22%2C%20%22https%3A//github.com/meteor/guide/pull/225%23discussion_r52136258%22%2C%20%22https%3A//github.com/meteor/guide/pull/225%23issuecomment-181226135%22%2C%20%22https%3A//github.com/meteor/guide/pull/225%23issuecomment-181226990%22%2C%20%22https%3A//github.com/meteor/guide/pull/225%23discussion_r52136622%22%2C%20%22https%3A//github.com/meteor/guide/pull/225%23discussion_r52136635%22%2C%20%22https%3A//github.com/meteor/guide/pull/225%23discussion_r52136668%22%2C%20%22https%3A//github.com/meteor/guide/pull/225%23discussion_r52136979%22%2C%20%22https%3A//github.com/meteor/guide/pull/225%23discussion_r52137002%22%2C%20%22https%3A//github.com/meteor/guide/pull/225%23discussion_r52137021%22%2C%20%22https%3A//github.com/meteor/guide/pull/225%23issuecomment-181715702%22%2C%20%22https%3A//github.com/meteor/guide/pull/225%23issuecomment-181716898%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%20ed044d7ea399d394bbd2166c1ead2ddb5cfa19a7%20content/build-tool.md%2013%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/225%23discussion_r52136224%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20would%20definitely%20make%20sense%20in%20the%20universe%20where%20a%20%60meteor%20create%60%20gives%20you%20an%20app%20with%20NPM%20dependencies.%20If%20we%20have%20%60meteor%20create%20--react%60%20or%20similar%2C%20that%20will%20be%20necessary%2C%20and%20I%20bet%20a%20Meteor%201.4%20app%20will%20require%20NPM%20dependencies%20for%20some%20core%20Meteor%20stuff%3F%22%2C%20%22created_at%22%3A%20%222016-02-08T06%3A27%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22Maybe%20we%20just%20have%20%60package.js%60%20in%20the%20boilerplate%20now%3F%20....%22%2C%20%22created_at%22%3A%20%222016-02-08T06%3A40%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22It%20just%20seems%20weird%20to%20me%20to%20have%20meteor%20create%20give%20you%20an%20empty%20%60package.json%60%20file%2C%20but%20maybe%20that%27s%20not%20so%20bad%3F%22%2C%20%22created_at%22%3A%20%222016-02-08T06%3A51%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20content/build-tool.md%3AL79-95%22%7D%2C%20%22Pull%20ed044d7ea399d394bbd2166c1ead2ddb5cfa19a7%20content/build-tool.md%2012%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/225%23discussion_r52136184%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22It%20should%20be%20%60--save%60%20for%20production%20deps%2C%20and%20%60--save-dev%60%20for%20development%20deps%2C%20right%3F%20Another%20place%20where%20in%20Meteor%20the%20package%20specifies%20it%20%28build%20plugin%2C%20debugOnly%29%20and%20in%20NPM%20the%20user%20does.%22%2C%20%22created_at%22%3A%20%222016-02-08T06%3A26%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20mean...%20how%20does%20this%20actually%20work%20in%20practice%3F%20I%20mean%20the%20difference%20between%20%60dependencies%60%20and%20%60devDependencies%60%20has%20a%20fixed%20meaning%20for%20an%20npm%20%2Amodule%2A%20which%20is%20irrelevant%20to%20a%20meteor%20%2Aapp%2A%2C%20I%20would%20have%20thought.%20Unless%20the%20build%20tool%20respects%20this%20somehow%3F%22%2C%20%22created_at%22%3A%20%222016-02-08T06%3A40%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22In%20an%20ideal%20world%2C%20when%20you%20deploy%20your%20app%20it%20would%20install%20your%20%60dependencies%60%20but%20not%20your%20%60devDependencies%60%20on%20the%20production%20server%2C%20so%20I%20think%20there%27s%20a%20valid%20distinction%20that%20a%20future%20Meteor%20tool%20should%20respect.%22%2C%20%22created_at%22%3A%20%222016-02-08T06%3A50%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20content/build-tool.md%3AL79-95%22%7D%2C%20%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/225%23issuecomment-181226135%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Is%20there%20some%20reason%20you%20decided%20to%20start%20documenting%20the%20PostCSS%20package%3F%22%2C%20%22created_at%22%3A%20%222016-02-08T06%3A30%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yeah%2C%20I%20thought%20it%20was%20simple%20enough%20now%20and%20unlikely%20to%20change.%22%2C%20%22created_at%22%3A%20%222016-02-08T06%3A38%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22Do%20you%20think%20it%20was%20a%20mistake%20to%20document%20it%3F%22%2C%20%22created_at%22%3A%20%222016-02-09T05%3A23%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22No%20I%20think%20it%27s%20fine%21%20You%27re%20right%20that%20it%27s%20a%20lot%20more%20straightforward%20when%20you%20don%27t%20have%20to%20worry%20about%20meteorhacks%3Anpm.%22%2C%20%22created_at%22%3A%20%222016-02-09T05%3A35%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20ed044d7ea399d394bbd2166c1ead2ddb5cfa19a7%20content/build-tool.md%2014%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/guide/pull/225%23discussion_r52136258%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20think%20it%20should%20be%20up%20to%20users%20to%20run%20%60npm%20install%60%20vs.%20Meteor%20somehow%20doing%20it%20for%20you%2C%20but%20we%20should%20try%20to%20figure%20out%20a%20way%20to%20warn%20users%20when%20their%20dependencies%20aren%27t%20installed%3F%20This%20could%20be%20as%20easy%20as%20something%20in%20%60.meteor/local%60%20which%20is%20a%20straight%20copy%20of%20%60package.json%60%2C%20and%20complains%20if%20it%27s%20different.%22%2C%20%22created_at%22%3A%20%222016-02-08T06%3A28%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yeah.%20I%20guess%20we%20leave%20this%20here%20until%20we%20know%20the%20answer%20to%20this.%22%2C%20%22created_at%22%3A%20%222016-02-08T06%3A41%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/132554%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tmeasday%22%7D%7D%2C%20%7B%22body%22%3A%20%22If%20the%20above%20is%20easy%20to%20implement%2C%20it%20could%20be%20a%20good%20suggestion%20to%20the%20platform%20team.%20I%20don%27t%20think%20they%20have%20any%20plans%20about%20this%20right%20now%20but%20I%20could%20be%20wrong.%22%2C%20%22created_at%22%3A%20%222016-02-08T06%3A51%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20content/build-tool.md%3AL79-95%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull ed044d7ea399d394bbd2166c1ead2ddb5cfa19a7 content/build-tool.md 12'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/225#discussion_r52136184'>File: content/build-tool.md:L79-95</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> It should be `--save` for production deps, and `--save-dev` for development deps, right? Another place where in Meteor the package specifies it (build plugin, debugOnly) and in NPM the user does.
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> I mean... how does this actually work in practice? I mean the difference between `dependencies` and `devDependencies` has a fixed meaning for an npm *module* which is irrelevant to a meteor *app*, I would have thought. Unless the build tool respects this somehow?
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> In an ideal world, when you deploy your app it would install your `dependencies` but not your `devDependencies` on the production server, so I think there's a valid distinction that a future Meteor tool should respect.
- [ ] <a href='#crh-comment-Pull ed044d7ea399d394bbd2166c1ead2ddb5cfa19a7 content/build-tool.md 13'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/225#discussion_r52136224'>File: content/build-tool.md:L79-95</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> This would definitely make sense in the universe where a `meteor create` gives you an app with NPM dependencies. If we have `meteor create --react` or similar, that will be necessary, and I bet a Meteor 1.4 app will require NPM dependencies for some core Meteor stuff?
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> Maybe we just have `package.js` in the boilerplate now? ....
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> It just seems weird to me to have meteor create give you an empty `package.json` file, but maybe that's not so bad?
- [ ] <a href='#crh-comment-Pull ed044d7ea399d394bbd2166c1ead2ddb5cfa19a7 content/build-tool.md 14'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/225#discussion_r52136258'>File: content/build-tool.md:L79-95</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> I think it should be up to users to run `npm install` vs. Meteor somehow doing it for you, but we should try to figure out a way to warn users when their dependencies aren't installed? This could be as easy as something in `.meteor/local` which is a straight copy of `package.json`, and complains if it's different.
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> Yeah. I guess we leave this here until we know the answer to this.
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> If the above is easy to implement, it could be a good suggestion to the platform team. I don't think they have any plans about this right now but I could be wrong.
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/guide/pull/225#issuecomment-181226135'>General Comment</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Is there some reason you decided to start documenting the PostCSS package?
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> Yeah, I thought it was simple enough now and unlikely to change.
- <a href='https://github.com/tmeasday'><img border=0 src='https://avatars.githubusercontent.com/u/132554?v=3' height=16 width=16'></a> Do you think it was a mistake to document it?
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> No I think it's fine! You're right that it's a lot more straightforward when you don't have to worry about meteorhacks:npm.


<a href='https://www.codereviewhub.com/meteor/guide/pull/225?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/meteor/guide/pull/225?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/meteor/guide/pull/225'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>