### PR TITLE
Changed ValidatedMethod input schema properties to validate.

### DIFF
--- a/content/security.md
+++ b/content/security.md
@@ -117,9 +117,9 @@ The best way to make your app secure is to understand all of the possible inputs
 ```js
 Lists.methods.makePrivate = new ValidatedMethod({
   name: 'Lists.methods.makePrivate',
-  schema: new SimpleSchema({
+  validate: new SimpleSchema({
     listId: { type: String }
-  }),
+  }).validator(),
   run({ listId }) {
     if (!this.userId) {
       throw new Meteor.Error('Lists.methods.makePrivate.notLoggedIn',
@@ -149,10 +149,10 @@ However, this doesn't mean you can't have any flexibility in your Methods. Let's
 ```js
 const Meteor.users.methods.setUserData = new ValidatedMethod({
   name: 'Meteor.users.methods.setUserData',
-  schema: new SimpleSchema({
+  validate: new SimpleSchema({
     fullName: { type: String, optional: true },
     dateOfBirth: { type: Date, optional: true },
-  }),
+  }).validator(),
   run(fieldsToSet) {
     Meteor.users.update(this.userId, {
       $set: fieldsToSet

--- a/content/ui-ux.md
+++ b/content/ui-ux.md
@@ -443,9 +443,9 @@ Sometimes the user may be interested in knowing when the update has hit the serv
 ```js
 Messages.methods.insert = new ValidatedMethod({
   name: 'Messages.methods.insert',
-  schema: new SimpleSchema({
+  validate: new SimpleSchema({
     text: {type: String}
-  }),
+  }).validator(),
   run(message) {
     // In the simulation (on the client), we add an extra pending field.
     // It will be removed when the server comes back with the "true" data.


### PR DESCRIPTION
Hi guys - I just noticed one more small thing. Some of the existing `ValidatedMethod` examples are using a `schema` property on input, but haven't defined a mixin that allows the `schema` property. To help reduce confusion I've switched these over to use `validate`. Thanks!