### PR TITLE
Method name typo fix in Blaze "passing up" example code

### DIFF
--- a/content/blaze.md
+++ b/content/blaze.md
@@ -426,7 +426,7 @@ Template.Lists_show.helpers({
 
 Template.Todos_item.events({
   'focus input[type=text]'() {
-    this.onEditing(true);
+    this.onEditingChange(true);
   }
 });
 ```


### PR DESCRIPTION
See referenced code here:
https://github.com/meteor/todos/blob/741076e6a0450667eb93e21ccbe69beabaa05c9e/imports/ui/components/todos-item.js#L43