### PR TITLE
Fix variable name editingTodo in Blaze example

### DIFF
--- a/content/blaze.md
+++ b/content/blaze.md
@@ -321,7 +321,7 @@ Template.Lists_show.helpers({
 
 Template.Lists_show.events({
   'click .js-cancel'(event, instance) {
-    instance.state.set('editing', false);
+    instance.state.set('editingTodo', false);
   }
 });
 ```


### PR DESCRIPTION
I believe the name of this variable should be `editingTodo`, considering the rest of the code snippet.