### PR TITLE
Add ESLint-plugin-Meteor

### DIFF
--- a/content/code-style.md
+++ b/content/code-style.md
@@ -85,19 +85,25 @@ Below, you can find directions for setting up automatic linting at many differen
 To setup ESLint in your application, you can install the following NPM packages:
 
 ```
-npm install --save-dev eslint eslint-plugin-react eslint-config-airbnb
+npm install --save-dev eslint eslint-plugin-react eslint-plugin-meteor eslint-config-airbnb
 ```
 
-You can also add a `eslintConfig` section to your `package.json` to specify that you'd like to use the AirBnB config. You can also setup any extra rules you want to change, as well as adding a lint NPM command:
+You can also add a `eslintConfig` section to your `package.json` to specify that you'd like to use the AirBnB config, and to enable [ESLint-plugin-Meteor](https://github.com/dferber90/eslint-plugin-meteor). You can also setup any extra rules you want to change, as well as adding a lint NPM command:
 
 ```
 {
   ...
   "scripts": {
-    "lint": "eslint . || true"
+    "lint": "eslint ."
   },
   "eslintConfig": {
-    "extends": "airbnb/base",
+    "plugins": [
+      "meteor"
+    ],
+    "extends": [
+      "airbnb/base",
+      "plugin:meteor/guide"
+    ],
     "rules": {}
   }
 }


### PR DESCRIPTION
This PR adds [ESLint-plugin-Meteor](https://github.com/dferber90/eslint-plugin-meteor) to the section *Installing and running ESLint*.

**Changes**
- add eslint-plugin-meteor
- remove `|| true` from npm lint script to keep proper exit code

**Open questions**
This commit adds `plugin:meteor/guide`, but there is no such rule preset yet. We'll discuss which rules should be part of it and add them then. Until then, I'll make `plugin:meteor/guide` an empty preset (all rules disabled).

As discussed in meteor/todos#88.