### PR TITLE
Setting order for proper navigation arrows

### DIFF
--- a/content/1.3-migration.md
+++ b/content/1.3-migration.md
@@ -1,6 +1,6 @@
 ---
 title: Migrating to Meteor 1.3
-order: 20
+order: 3
 description: How to migrate your application to use recommended best practice as of Meteor 1.3.
 discourseTopicId: 20190
 ---

--- a/content/accounts.md
+++ b/content/accounts.md
@@ -1,6 +1,6 @@
 ---
 title: Users and Accounts
-order: 6
+order: 13
 description: How to build user login functionality into a Meteor app. Let your users log in with passwords, Facebook, Google, GitHub, and more.
 discourseTopicId: 19664
 ---

--- a/content/angular.md
+++ b/content/angular.md
@@ -1,6 +1,6 @@
 ---
 title: Angular
-order: 11
+order: 24
 description: The correct place to find details about using Angular with Meteor
 ---
 

--- a/content/blaze.md
+++ b/content/blaze.md
@@ -1,6 +1,6 @@
 ---
 title: Blaze
-order: 9
+order: 22
 description: How to use Blaze, Meteor's frontend rendering system, to build usable and maintainable user interfaces.
 discourseTopicId: 19666
 ---

--- a/content/build-tool.md
+++ b/content/build-tool.md
@@ -1,6 +1,6 @@
 ---
 title: Build system
-order: 12
+order: 33
 description: How to use Meteor's build system to compile your app.
 discourseTopicId: 19669
 ---

--- a/content/collections.md
+++ b/content/collections.md
@@ -1,6 +1,6 @@
 ---
 title: Collections and Schemas
-order: 3
+order: 10
 description: How to define, use, and maintain MongoDB collections in Meteor.
 discourseTopicId: 19660
 ---

--- a/content/data-loading.md
+++ b/content/data-loading.md
@@ -1,6 +1,6 @@
 ---
 title: Publications and Data Loading
-order: 4
+order: 11
 description: How and where to load data in your Meteor app using publications and subscriptions.
 discourseTopicId: 19661
 ---

--- a/content/deployment.md
+++ b/content/deployment.md
@@ -1,6 +1,6 @@
 ---
 title: Deployment and Monitoring
-order: 13
+order: 41
 description: How to deploy, run, and monitor your Meteor app in production.
 discourseTopicId: 19668
 ---

--- a/content/methods.md
+++ b/content/methods.md
@@ -1,6 +1,6 @@
 ---
 title: "Methods"
-order: 5
+order: 12
 description: How to use Methods, Meteor's remote procedure call system, to write to the database.
 discourseTopicId: 19662
 ---

--- a/content/mobile.md
+++ b/content/mobile.md
@@ -1,6 +1,6 @@
 ---
 title: Mobile
-order: 13
+order: 32
 description: How to build mobile apps using Meteor's Cordova integration.
 discourseTopicId: 20195
 ---

--- a/content/react.md
+++ b/content/react.md
@@ -1,6 +1,6 @@
 ---
 title: React
-order: 10
+order: 23
 description: How to use React, Facebook's frontend rendering library, with Meteor.
 discourseTopicId: 20192
 ---

--- a/content/routing.md
+++ b/content/routing.md
@@ -1,6 +1,6 @@
 ---
 title: "URLs and Routing"
-order: 4
+order: 20
 description: How to drive your Meteor app's UI using URLs with FlowRouter.
 discourseTopicId: 19663
 ---

--- a/content/security.md
+++ b/content/security.md
@@ -1,6 +1,6 @@
 ---
 title: "Security"
-order: 12
+order: 40
 description: How to secure your Meteor app.
 discourseTopicId: 19667
 ---

--- a/content/testing.md
+++ b/content/testing.md
@@ -1,6 +1,6 @@
 ---
 title: "Testing"
-order: 7
+order: 14
 description: How to test your Meteor application
 discourseTopicId: 20191
 ---

--- a/content/ui-ux.md
+++ b/content/ui-ux.md
@@ -1,6 +1,6 @@
 ---
 title: User Interfaces
-order: 8
+order: 21
 description: General tips for structuring your UI code, independent of your view rendering technology.
 discourseTopicId: 19665
 ---

--- a/content/using-packages.md
+++ b/content/using-packages.md
@@ -1,5 +1,6 @@
 ---
 title: Using Packages
+order: 30
 discourseTopicId: 20192
 ---
 

--- a/content/writing-packages.md
+++ b/content/writing-packages.md
@@ -1,5 +1,6 @@
 ---
 title: Writing Packages
+order: 31
 discourseTopicId: 20194
 ---
 


### PR DESCRIPTION
I've set the order attribute on almost all pages, so that the navigation arrows work in the way how I expect them:

← Go to the previous item of the sidebar              Go to the next item of the sidebar →

The first part (until the first horizontal line in the sidebar) goes from 0 to 9, the second part from 10 to 19, etc. 

An update to README.md is not necessary, as there is no content change.