### PR TITLE
Add info for migrating from local packages to modules

### DIFF
--- a/content/1.3-migration.md
+++ b/content/1.3-migration.md
@@ -45,20 +45,21 @@ meteor npm install --save meteor-node-stubs
 - If you are using app-local packages to control load order and write unit tests for your application, we recommend you switch to using modules:
  - Remove code related to the [Package API](http://docs.meteor.com/#/full/packagejs) from the `package.js` files and rename them to `index.js`, 
  - Move your local packages to the `imports/` directory.
- - Add the necessary import statements to each of the modules in your packages.
+ - Add the necessary `import` statements to each of the modules in your packages.
+ - Add `export` statements to each of your packages exports.
 
 ```js
-api.use('meteor');
-// Turns into
-import { Meteor } from 'meteor/meteor';
-
 api.addFiles('file.js');
-// Turns into
+// For files that are not imported elsewhere, this turns into
 import './file.js';
 
-// imports/main.js
-// Don't forget to import the package!
-import './local_package/index';
+// Remove
+api.export('Foo');
+// Foo must be explicitly exported
+export default Foo;
+
+// client/main.js
+import '/imports/localPackage';
 ```
 - You can read about our recommended structure for applications and modules in the [Application Structure article](structure.html) of the Meteor Guide, and how to test them in the [Testing article](testing.html).
  

--- a/content/1.3-migration.md
+++ b/content/1.3-migration.md
@@ -42,8 +42,26 @@ import { EJSON } from 'meteor/ejson';
 meteor npm install --save meteor-node-stubs
 ```
 
-- If you are using app-local packages to control load order and write unit tests for your application, we recommend you switch to using modules. You can read about our recommended structure for applications and modules in the [Application Structure article](structure.html) of the Meteor Guide, and how to test them in the [Testing article](testing.html).
+- If you are using app-local packages to control load order and write unit tests for your application, we recommend you switch to using modules:
+ - Remove code related to the [Package API](http://docs.meteor.com/#/full/packagejs) from the `package.js` files and rename them to `index.js`, 
+ - Move your local packages to the `imports/` directory.
+ - Add the necessary import statements to each of the modules in your packages.
 
+```js
+api.use('meteor');
+// Turns into
+import { Meteor } from 'meteor/meteor';
+
+api.addFiles('file.js');
+// Turns into
+import './file.js';
+
+// imports/main.js
+// Don't forget to import the package!
+import './local_package/index';
+```
+- You can read about our recommended structure for applications and modules in the [Application Structure article](structure.html) of the Meteor Guide, and how to test them in the [Testing article](testing.html).
+ 
 - If you are using Atmosphere packages which simply wrap npm packages, both on the client and server, it is now recommended that you simply install them using npm. Run `npm init` to initialize your `package.json` and install packages with `npm install --save` (or `npm install --save-dev` if it's development dependency for testing etc.). We have [some tips](using-packages.html#async-callbacks) about how to use npm packages written in an asyncronous style.
 
 Also, you should no longer need to use the [`meteorhacks:npm`](https://atmospherejs.com/meteorhacks/npm) package.

--- a/content/1.3-migration.md
+++ b/content/1.3-migration.md
@@ -53,8 +53,10 @@ api.addFiles('file.js');
 // For files that are not imported elsewhere, this turns into
 import './file.js';
 
-// Remove
+// Remove from package.js
 api.export('Foo');
+
+// localPackage/foo.js
 // Foo must be explicitly exported
 export default Foo;
 


### PR DESCRIPTION
This PR adds a few tips to the 'Recommended change: use modules' section of the 'Migrating to Meteor 1.3' article on converting an app-local packages structure to a modules-based structure.

Ref: https://forums.meteor.com/t/how-to-migrating-from-all-in-packages-to-1-3-modules/20681/3