### PR TITLE
Usage of super() outside of constructor replaced by super.methodname()

### DIFF
--- a/content/collections.md
+++ b/content/collections.md
@@ -216,7 +216,7 @@ class ListsCollection extends Mongo.Collection {
 
     // Call the original `insert` method, which will validate
     // against the schema
-    return super(list, callback);
+    return super.insert(list, callback);
   }
 }
 
@@ -234,7 +234,7 @@ class ListsCollection extends Mongo.Collection {
   // ...
   remove(selector, callback) {
     Package.todos.Todos.remove({listId: selector});
-    return super(selector, callback);
+    return super.remove(selector, callback);
   }
 }
 ```


### PR DESCRIPTION
This the syntax that seemed to work in Meteor 1.2, did not build in Meteor 1.3.1. 
The change is in line with https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/super