### PR TITLE
Remove self-closing div from documentation

### DIFF
--- a/content/react.md
+++ b/content/react.md
@@ -56,7 +56,7 @@ Meteor.startup(() => {
 });
 ```
 
-You need to include a `<div id="app"/>` in your body's HTML somewhere of course.
+You need to include a `<div id="app"></div>` in your body's HTML somewhere of course.
 
 Every new Meteor app includes Blaze, Meteor's default templating system, by default. If you are not planning on [using React and Blaze together](#using-with-blaze), you can remove Blaze from your project by running:
 


### PR DESCRIPTION
Thanks for submitting a PR! We'll try to look at it as soon as possible.

If you are adding significant new content, please take a moment to include an update to the [changelog](https://github.com/meteor/guide/blob/master/CHANGELOG.md) in your PR.

Use this field to describe your pull request.

If I do this, meteor crashes with the following exception:
```
Errors prevented startup:                  
   
   While processing files with templating (for target web.browser):
   client/main.html:8: Only certain elements like BR, HR, IMG, etc. (and foreign elements like SVG) are
   allowed to self-close
   ...1>    <div id="app"/>
```
Therefore, I think it is better to not show code-examples which won't work.

Or am I missing something?