### PR TITLE
Link to original 'faker' package instead of fork

### DIFF
--- a/content/testing.md
+++ b/content/testing.md
@@ -136,7 +136,7 @@ As we've placed the code above in a test file, it *will not* load in normal deve
 
 Often it's sensible to create a set of data to run your test against. You can use standard `insert()` calls against your collections to do this, but often it's easier to create *factories* which help encode random test data. A great package to use to do this is [`dburles:factory`](https://atmospherejs.com/dburles/factory).
 
-In the Todos example app, we define a factory to describe how to create a test todo item, using the [`faker`](https://www.npmjs.com/package/Faker) npm package:
+In the Todos example app, we define a factory to describe how to create a test todo item, using the [`faker`](https://www.npmjs.com/package/faker) npm package:
 
 ```js
 import faker from 'faker';


### PR DESCRIPTION
The guide links to an old fork of 'faker' that is also registered on npm (as 'Faker' instead of 'faker'). The Todos app uses the up-to-date version.