### PR TITLE
Fix link to eslint Meteor plugin

### DIFF
--- a/content/code-style.md
+++ b/content/code-style.md
@@ -105,7 +105,7 @@ You can also add a `eslintConfig` section to your `package.json` to specify that
     ],
     "extends": [
       "airbnb/base",
-      "plugin:meteor/guide"
+      "plugin:meteor/recommended"
     ],
     "rules": {}
   }


### PR DESCRIPTION
I could not find a any plugin ["plugin:meteor/guide"], but there is a ["plugin:meteor/recommended"].

https://github.com/dferber90/eslint-plugin-meteor#configuration