### PR TITLE
provide correct ways to use Moment.js

### DIFF
--- a/content/using-packages.md
+++ b/content/using-packages.md
@@ -57,6 +57,8 @@ import moment from 'moment';
 const moment = require('moment');
 ```
 
+This works in most cases. But since moment is special, you need use either `import * as moment from 'moment';` or `import moment = require('moment');`
+
 This imports the default export from the package into the symbol `moment`.
 
 You can also import specific functions from a package using the destructuring syntax:


### PR DESCRIPTION
Moment.js is special.
Please check second answer [here](http://stackoverflow.com/questions/35166168/how-to-use-moment-js-library-in-angular-2-typescript-app) for details.

So instead of using
```
import moment from 'moment';
```

The correct ways should be either of these below:
```
import * as moment from 'moment';
import moment = require('moment');
```