### PR TITLE
react-router does not work refer to react.md

### DIFF
--- a/content/react.md
+++ b/content/react.md
@@ -291,12 +291,12 @@ import NotFoundPage from '../../ui/pages/NotFoundPage.jsx';
 
 export const renderRoutes = () => (
   <Router history={browserHistory}>
-    <Route path="/" component={AppContainer}>
+    <Route path="/" component={AppContainer}></Route>
       <Route path="lists/:id" component={ListContainer}/>
       <Route path="signin" component={AuthPageSignIn}/>
       <Route path="join" component={AuthPageJoin}/>
       <Route path="*" component={NotFoundPage}/>
-    </Route>
+    
   </Router>
 );
 ```


### PR DESCRIPTION
In practice,whatever the path I type,it only show the content of first router.
After remove the nesting,it works.My env as follows：

http://localhost:3000/
METEOR@1.3.1
```json
{
  "dependencies": {
    "meteor-node-stubs": "~0.2.0",
    "react": "^15.0.1",
    "react-dom": "^15.0.1",
    "react-router": "^2.1.1"
  }
}
```