### PR TITLE
Add sections on creating an npm package and overriding a published one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ order: 1001
 description: A log of significant changes to the Meteor Guide.
 ---
 
+- 2016/04/16: Added "Writing Packages - Creating an npm package" and "Using Packages - Overriding packages - npm". [PR #381](https://github.com/meteor/guide/pull/381)
 - 2016/04/07: Add more examples and details on application structure using imports. [PR #356](https://github.com/meteor/guide/pull/356)
 - 2016/04/04: Add more content on writing and publishing Atmosphere packages. [PR #339](https://github.com/meteor/guide/pull/339)
 - 2016/04/03: Add back in build tool default loading order rules. [PR #340](https://github.com/meteor/guide/pull/340)

--- a/content/using-packages.md
+++ b/content/using-packages.md
@@ -251,7 +251,9 @@ Now `left-pad` is included in your `package.json`, and the code has been downloa
 git add -f node_modules/left_pad/
 ```
 
-Now you can edit the package, commit, and push, and your teammates will get your version of the package. To ensure that your package doesn't get overwritten during an `npm update`, change the default [caret version range](https://docs.npmjs.com/misc/semver#caret-ranges-123-025-004) in your `package.json` to an exact version. Before:
+Now you can edit the package, commit, and push, and your teammates will get your version of the package. To ensure that your package doesn't get overwritten during an `npm update`, change the default [caret version range](https://docs.npmjs.com/misc/semver#caret-ranges-123-025-004) in your `package.json` to an exact version.
+
+Before:
 
 ```json
 "left-pad": "^1.0.2",

--- a/content/using-packages.md
+++ b/content/using-packages.md
@@ -251,7 +251,7 @@ Now `left-pad` is included in your `package.json`, and the code has been downloa
 git add -f node_modules/left_pad/
 ```
 
-Now you can edit the package, commit, and push, and your teammates will get your version of the package. To ensure that your package doesn't get overwritten during an `npm update`, change the default caret version range in your `package.json` to an exact version. Before:
+Now you can edit the package, commit, and push, and your teammates will get your version of the package. To ensure that your package doesn't get overwritten during an `npm update`, change the default [caret version range](https://docs.npmjs.com/misc/semver#caret-ranges-123-025-004) in your `package.json` to an exact version. Before:
 
 ```json
 "left-pad": "^1.0.2",

--- a/content/using-packages.md
+++ b/content/using-packages.md
@@ -233,15 +233,47 @@ sendTextMessage() {
 }
 ```
 
-<h2 id="atmosphere-overriding">Overriding packages from Atmosphere with a local version</h2>
+<h2 id="overriding-packages">Overriding packages with a local version</h2>
 
-A Meteor app can load packages in one of three ways, and it looks for a matching package name in the following order:
+If you need to modify a package to do something that the published version doesn't do, you can edit a local version of the package on your computer.
+
+<h3 id="npm-overriding">npm</h3>
+
+Let's say you want to modify the `left-pad` npm package. If you haven't already, run inside your app directory:
+
+```bash
+meteor npm install --save left-pad
+```
+
+Now `left-pad` is included in your `package.json`, and the code has been downloaded to `node_modules/left_pad/`. Add the new directory to source control with:
+
+```bash
+git add -f node_modules/left_pad/
+```
+
+Now you can edit the package, commit, and push, and your teammates will get your version of the package. To ensure that your package doesn't get overwritten during an `npm update`, change the default caret version range in your `package.json` to an exact version. Before:
+
+```json
+"left-pad": "^1.0.2",
+```
+
+After:
+
+```json
+"left-pad": "1.0.2",
+```
+
+An alternative method is maintaining a separate repository for the package and changing the `package.json` version number [to a git URL or tarball](http://debuggable.com/posts/how-to-fork-patch-npm-modules:4e2eb9f3-e584-44be-b1a9-3db7cbdd56cb), but every time you edit the separate repo, you'll need to commit, push, and `npm update left-pad`.
+
+<h3 id="atmosphere-overriding">Atmosphere</h3>
+
+A Meteor app can load Atmosphere packages in one of three ways, and it looks for a matching package name in the following order:
 
 1. Package source code in the `packages/` directory inside your app.
 2. Package source code in directories indicated by setting a `PACKAGE_DIRS` environment variable before running any `meteor` command. You can add multiple directories by separating the paths with a `:` on OSX or Linux, or a `;` on Windows. For example: `PACKAGE_DIRS=../first/directory:../second/directory`, or on Windows: `set PACKAGE_DIRS=..\first\directory;..\second\directory`.
 3. Pre-built package from Atmosphere. The package is cached in `~/.meteor/packages` on Mac/Linux or `%LOCALAPPDATA%\.meteor\packages` on Windows, and only loaded into your app as it is built.
 
-If you need to patch a package to do something that the published version doesn't do, then you can use (1) or (2) to override the version from Atmosphere. You can even do this to load patched versions of Meteor core packages - just copy the code of the package from [Meteor's GitHub repository](https://github.com/meteor/meteor/tree/devel/packages), and edit away.
+You can use (1) or (2) to override the version from Atmosphere. You can even do this to load patched versions of Meteor core packages - just copy the code of the package from [Meteor's GitHub repository](https://github.com/meteor/meteor/tree/devel/packages), and edit away.
 
 One difference between pre-published packages and local app packages is that the published packages have any binary dependencies pre-built. This should only affect a small subset of packages. If you clone the source code into your app, you need to make sure you have any compilers required by that package.
 

--- a/content/writing-packages.md
+++ b/content/writing-packages.md
@@ -53,24 +53,19 @@ myPackageLog(); // > "logged from my-package"
 
 <h3 id="including-in-app">Including in your app</h3>
 
-When you are developing a new npm package for your app, there are a couple ways to include the package in your app:
+When you are developing a new npm package for your app, there are a couple methods for including the package in your app:
 
-1. Place the package in your app's `node_modules/` directory, and add the package to source control. Do this when you want everything in a single repository.
-1. Place the package outside your app's directory in a separate repository and use `npm link`. Do this when you want to use the package in multiple apps.
-
-<h4 id="inside-node-modules">Placing inside node_modules</h3>
+- **Inside node_modules**: Place the package in your app's `node_modules/` directory, and add the package to source control. Do this when you want everything in a single repository.
 
 ```bash
 cd my-app/node_modules/
 mkdir my-package
 cd my-package/
 meteor npm init
-git add -f ./ # (or use a git submodule)
+git add -f ./ # or use a git submodule
 ```
 
-Then edit the `dependencies` object of `my-app/package.json`, adding `"my-package": "1.0.0"` (use the same version number you chose during `meteor npm init`).
-
-<h4 id="using-npm-link">Using npm link</h3>
+- **npm link**: Place the package outside your app's directory in a separate repository and use [`npm link`](https://docs.npmjs.com/cli/link). Do this when you want to use the package in multiple apps.
 
 ```bash
 cd ~/
@@ -81,7 +76,9 @@ cd ~/my-app/
 meteor npm link ~/my-package
 ```
 
-Then edit the `dependencies` object of `my-app/package.json`, adding `"my-package": "1.0.0"` (use the same version number you chose during `meteor npm init`).
+Other developers will also need to run the `npm link` command.
+
+After either method, edit the `dependencies` attribute of `my-app/package.json`, adding `"my-package": "1.0.0"` (use the same version number you chose during `meteor npm init`).
 
 <h3 id="publishing-npm">Publishing your package</h3>
 
@@ -89,7 +86,7 @@ You can share your package with others by publishing it to the npm registry. Whi
 
 To publish publicly, [follow these instructions](https://docs.npmjs.com/getting-started/publishing-npm-packages). When you're done, anyone can add your package to their app with `npm install --save your-package`.
 
-If you want to share packages during development, we recommend using source control instead of the registry. If you use the registry, then every time you change the package, you need to increment the version number, publish, and then `npm update my-package` inside your app.
+If you want to share packages during development, we recommend using the [above methods](#including-in-app) instead of the registry. If you use the registry, then every time you change the package, you need to increment the version number, publish, and then `npm update my-package` inside your app.
 
 <h2 id="creating">Creating an Atmosphere package</h2>
 

--- a/content/writing-packages.md
+++ b/content/writing-packages.md
@@ -24,6 +24,10 @@ However, if your package depends on an Atmosphere package (which, in Meteor 1.3,
 
 <h2 id="creating-npm">Creating an npm package</h2>
 
+If you want to override a package that already exists in the npm registry, [use this method](using-packages.html#npm-overriding).
+
+To create a new package:
+
 ```bash
 mkdir my-package
 cd my-package/

--- a/content/writing-packages.md
+++ b/content/writing-packages.md
@@ -7,9 +7,10 @@ discourseTopicId: 20194
 After reading this article, you'll know:
 
 1. When to create an npm package and when to create an Atmosphere package
-2. The basics of writing an Atmosphere package
-3. How to depend on other packages, both from Atmosphere and npm
-4. How an Atmosphere package can integrate with Meteor's build system
+1. The basics of writing an npm package
+1. The basics of writing an Atmosphere package
+1. How to depend on other packages, both from Atmosphere and npm
+1. How an Atmosphere package can integrate with Meteor's build system
 
 The Meteor platform supports two package systems: [npm](https://www.npmjs.com), a repository of JavaScript modules for Node.js and the browser, and [Atmosphere](https://atmospherejs.com), a repository of packages written specifically for Meteor.
 
@@ -19,11 +20,72 @@ With the release of version 1.3, Meteor has full support for npm. In the future,
 
 If you want to distribute and reuse code that you've written for a Meteor application, then you should consider publishing that code on npm if it's general enough to be consumed by a wider JavaScript audience. It's simple to [use npm packages from Meteor applications](using-packages.html#npm), and possible to [use npm packages from Atmosphere packages](#npm-dependencies), so even if your main audience is Meteor developers, npm might be the best choice.
 
-The practice of writing npm packages is [well documented](https://docs.npmjs.com/getting-started/creating-node-modules) and we won't cover it here.
-
 However, if your package depends on an Atmosphere package (which, in Meteor 1.3, includes the Meteor core packages), or needs to take advantage of Meteor's [build system](build-tool.html), then writing an Atmosphere package might be the best option.
 
-This article will cover some tips on how to do that.
+<h2 id="creating-npm">Creating an npm package</h2>
+
+```bash
+mkdir my-package
+cd my-package/
+meteor npm init
+```
+
+The last command creates a `package.json` file and prompts you for the package information. You may skip everything but `name`, `version`, and `entry point`. You can use the default `index.js` for `entry point`. This file is where you set your package's exports:
+
+```js
+// my-package/index.js
+exports.myPackageLog = function() {
+  console.log("logged from my-package");
+};
+```
+
+Now apps that include this package can do:
+
+```js
+import { myPackageLog } from 'my-package'
+
+myPackageLog(); // > "logged from my-package"
+```
+
+<h3 id="including-in-app">Including in your app</h3>
+
+When you are developing a new npm package for your app, there are a couple ways to include the package in your app:
+
+1. Place the package in your app's `node_modules/` directory, and add the package to source control. Do this when you want everything in a single repository.
+1. Place the package outside your app's directory in a separate repository and use `npm link`. Do this when you want to use the package in multiple apps.
+
+<h4 id="inside-node-modules">Placing inside node_modules</h3>
+
+```bash
+cd my-app/node_modules/
+mkdir my-package
+cd my-package/
+meteor npm init
+git add -f ./ # (or use a git submodule)
+```
+
+Then edit the `dependencies` object of `my-app/package.json`, adding `"my-package": "1.0.0"` (use the same version number you chose during `meteor npm init`).
+
+<h4 id="using-npm-link">Using npm link</h3>
+
+```bash
+cd ~/
+mkdir my-package
+cd my-package/
+meteor npm init
+cd ~/my-app/
+meteor npm link ~/my-package
+```
+
+Then edit the `dependencies` object of `my-app/package.json`, adding `"my-package": "1.0.0"` (use the same version number you chose during `meteor npm init`).
+
+<h3 id="publishing-npm">Publishing your package</h3>
+
+You can share your package with others by publishing it to the npm registry. While most packages are public, you can control who may view and use your package with [private modules](https://docs.npmjs.com/private-modules/intro)).
+
+To publish publicly, [follow these instructions](https://docs.npmjs.com/getting-started/publishing-npm-packages). When you're done, anyone can add your package to their app with `npm install --save your-package`.
+
+If you want to share packages during development, we recommend using source control instead of the registry. If you use the registry, then every time you change the package, you need to increment the version number, publish, and then `npm update my-package` inside your app.
 
 <h2 id="creating">Creating an Atmosphere package</h2>
 


### PR DESCRIPTION
The previously linked npm explanation of creating an npm package is heavyweight for a Meteor dev's purposes (and doesn't cover the common case of private code). Using their method, you need to publish and update after each change. A Meteor dev is usually creating a package in support of their app, and is usually developing it inside the app, so using source control makes more sense. Also, the source control way is more familiar coming from `packages/`.

Also fixes #378