### PR TITLE
Switch order of code style and application structure sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ order: 1001
 description: A log of significant changes to the Meteor Guide.
 ---
 
-- 2016/04/16: Switch order of Code Style and Application structure sections. [PR #381](https://github.com/meteor/guide/pull/382)
+- 2016/04/16: Switch order of Code Style and Application structure sections. [PR #381](https://github.com/meteor/guide/pull/383)
 - 2016/04/16: Added "Writing Packages - Creating an npm package" and "Using Packages - Overriding packages - npm". [PR #381](https://github.com/meteor/guide/pull/381)
 - 2016/04/07: Add more examples and details on application structure using imports. [PR #356](https://github.com/meteor/guide/pull/356)
 - 2016/04/04: Add more content on writing and publishing Atmosphere packages. [PR #339](https://github.com/meteor/guide/pull/339)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ order: 1001
 description: A log of significant changes to the Meteor Guide.
 ---
 
+- 2016/04/16: Switch order of Code Style and Application structure sections. [PR #381](https://github.com/meteor/guide/pull/382)
 - 2016/04/16: Added "Writing Packages - Creating an npm package" and "Using Packages - Overriding packages - npm". [PR #381](https://github.com/meteor/guide/pull/381)
 - 2016/04/07: Add more examples and details on application structure using imports. [PR #356](https://github.com/meteor/guide/pull/356)
 - 2016/04/04: Add more content on writing and publishing Atmosphere packages. [PR #339](https://github.com/meteor/guide/pull/339)

--- a/content/code-style.md
+++ b/content/code-style.md
@@ -1,6 +1,6 @@
 ---
 title: Code style
-order: 2
+order: 1
 description: Suggested style guidelines for your code.
 discourseTopicId: 20189
 ---

--- a/content/structure.md
+++ b/content/structure.md
@@ -1,6 +1,6 @@
 ---
 title: Application structure
-order: 1
+order: 2
 description: How to structure your Meteor app with ES2015 modules, ship code to the client and server, and split your code into multiple apps.
 discourseTopicId: 20187
 ---

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -19,8 +19,8 @@ versions:
 sidebar_categories:
   null:
     - index
-    - structure
     - code-style
+    - structure
     - 1.3-migration
   Data:
     - collections


### PR DESCRIPTION
I think this flows better as it makes more sense to cover code style, etc. before talking about Meteor specific application structure. Resolves #370.