### PR TITLE
Clarify methods of importing styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-title: Change log
+title: Changelog
 order: 1001
 description: A log of significant changes to the Meteor Guide.
 ---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 ---
-title: Contribution guidelines
+title: Contribution Guidelines
 order: 1000
 description: Tips for contributing to the Meteor Guide.
 ---
@@ -23,6 +23,10 @@ Things to be aware of:
 // good
 <h2 id="schemas-with-collections">Using schemas with collections</h2>
 ```
+
+#### Titles and headers
+
+Article titles are `Title Case`, and headers are `Sentence case`.
 
 #### Always put a blank line after each header
 

--- a/content/build-tool.md
+++ b/content/build-tool.md
@@ -1,5 +1,5 @@
 ---
-title: Build system
+title: Build System
 order: 33
 description: How to use Meteor's build system to compile your app.
 discourseTopicId: 19669
@@ -106,36 +106,44 @@ Read the documentation for each package listed below to see how to indicate whic
 
 <h3 id="css-importing">Importing styles</h3>
 
-In all three Meteor supported CSS pre-processors you can import other style files from both relative and absolute paths in your app and from both npm and Meteor Atmosphere packages. You can also import CSS from a JavaScript file if you have the `ecmascript` package installed.
-
-Importing styles from your app:
+In all three Meteor supported CSS pre-processors you can import other style files from both relative and absolute paths in your app and from both npm and Meteor Atmosphere packages. 
 
 ```less
+// foo.less
 @import '../stylesheets/colors.less';   // a relative path
 @import '{}/imports/ui/stylesheets/button.less';   // absolute path with `{}` syntax
 ```
+
+You can also import CSS from a JavaScript file if you have the `ecmascript` package installed:
+
 ```js
-import '../stylesheets/styles.css';  // import CSS from JS
+// foo.js
+import '../stylesheets/styles.css';
 ```
+
+> When importing CSS from a JavaScript file, that CSS is not bundled with the rest of the CSS processed with the Meteor Build tool, but instead is put in your app's `<head>` tag inside `<style>...</style>` after the main concatenated CSS file.
 
 Importing styles from an Atmosphere package using the `{}` package name syntax:
 
 ```less
+// foo.less
 @import '{my-package:pretty-buttons}/buttons/styles.import.less';
 ```
 
-> CSS files in an Atmosphere package are declared with `api.addFiles`, and therefore will be eagerly evaluated, and automatically bundled with all the other CSS in your app.
+> CSS files in an Atmosphere package are declared with [`api.addFiles`](http://docs.meteor.com/#/full/pack_addFiles), and therefore will be eagerly evaluated, and automatically bundled with all the other CSS in your app.
 
 Importing styles from an npm package using the `{}` syntax:
 
 ```less
+// foo.less
 @import '{}/node_modules/npm-package-name/button.less';
 ```
 ```js
-import 'npm-package-name/stylesheets/styles.css';  // import CSS from JS
+// foo.js
+import 'npm-package-name/stylesheets/styles.css';
 ```
 
-For more examples and details on importing styles and using `@imports` with packages see [Using Packages](using-packages.html) in the Meteor Guide.
+For more examples and details on importing styles and using `@imports` with packages see the [Using Packages](using-packages.html#npm-styles) article.
 
 <h3 id="sass">Sass</h3>
 

--- a/content/build-tool.md
+++ b/content/build-tool.md
@@ -109,7 +109,6 @@ Read the documentation for each package listed below to see how to indicate whic
 In all three Meteor supported CSS pre-processors you can import other style files from both relative and absolute paths in your app and from both npm and Meteor Atmosphere packages. 
 
 ```less
-// foo.less
 @import '../stylesheets/colors.less';   // a relative path
 @import '{}/imports/ui/stylesheets/button.less';   // absolute path with `{}` syntax
 ```
@@ -117,7 +116,6 @@ In all three Meteor supported CSS pre-processors you can import other style file
 You can also import CSS from a JavaScript file if you have the `ecmascript` package installed:
 
 ```js
-// foo.js
 import '../stylesheets/styles.css';
 ```
 
@@ -126,7 +124,6 @@ import '../stylesheets/styles.css';
 Importing styles from an Atmosphere package using the `{}` package name syntax:
 
 ```less
-// foo.less
 @import '{my-package:pretty-buttons}/buttons/styles.import.less';
 ```
 
@@ -135,11 +132,9 @@ Importing styles from an Atmosphere package using the `{}` package name syntax:
 Importing styles from an npm package using the `{}` syntax:
 
 ```less
-// foo.less
 @import '{}/node_modules/npm-package-name/button.less';
 ```
 ```js
-// foo.js
 import 'npm-package-name/stylesheets/styles.css';
 ```
 

--- a/content/code-style.md
+++ b/content/code-style.md
@@ -1,5 +1,5 @@
 ---
-title: Code style
+title: Code Style
 order: 1
 description: Suggested style guidelines for your code.
 discourseTopicId: 20189

--- a/content/structure.md
+++ b/content/structure.md
@@ -1,5 +1,5 @@
 ---
-title: Application structure
+title: Application Structure
 order: 2
 description: How to structure your Meteor app with ES2015 modules, ship code to the client and server, and split your code into multiple apps.
 discourseTopicId: 20187

--- a/content/structure.md
+++ b/content/structure.md
@@ -36,6 +36,8 @@ import './loading.html';              // import Blaze compiled HTML from relativ
 import '/imports/ui/style.css';       // import CSS from absolute path
 ```
 
+> For more ways to import styles, see the [Build System](build-tool.html#css-importing) article.
+
 Meteor also supports the standard E2015 modules `export` syntax:
 
 ```js

--- a/content/using-packages.md
+++ b/content/using-packages.md
@@ -81,9 +81,10 @@ import { parse } from 'graphql/language';
 
 Using any of Meteor's [supported CSS pre-processors](build-tool.html#css) you can import other style files from both relative and absolute paths from an npm package.
 
-Importing styles from an npm package with an absolute path using the `{}` syntax:
+Importing styles from an npm package with an absolute path using the `{}` syntax, for instance with Less:
 
 ```less
+// foo.less
 @import '{}/node_modules/npm-package-name/button.less';
 ```
 
@@ -93,19 +94,14 @@ Importing styles from an npm package with a relative path:
 @import '../../node_modules/npm-package-name/colors.less';
 ```
 
-Importing CSS from an npm package from another style file;
-```js
-@import 'npm-package-name/stylesheets/styles.css';
-```
+You can also import CSS directly from a JavaScript file to control load order if you have the `ecmascript` package installed:
 
-You can also import CSS directly from a JavaScript file to control load order if you have the `ecmascript` package installed.
-
-Importing CSS from an npm package in a JavaScript file using ES2015 `import`;
 ```js
+// foo.js
 import 'npm-package-name/stylesheets/styles.css';
 ```
 
-> When importing CSS from a JavaScript file that CSS is not bundled with the rest of the CSS processed with the Meteor Build tool, but instead is put in your app's `<head>` tag inside `<style>...</style>` after the main concatenated CSS file.
+> When importing CSS from a JavaScript file, that CSS is not bundled with the rest of the CSS processed with the Meteor Build tool, but instead is put in your app's `<head>` tag inside `<style>...</style>` after the main concatenated CSS file.
 
 <h3 id="npm-shrinkwrap">npm shrinkwrap</h3>
 

--- a/content/using-packages.md
+++ b/content/using-packages.md
@@ -84,7 +84,6 @@ Using any of Meteor's [supported CSS pre-processors](build-tool.html#css) you ca
 Importing styles from an npm package with an absolute path using the `{}` syntax, for instance with Less:
 
 ```less
-// foo.less
 @import '{}/node_modules/npm-package-name/button.less';
 ```
 
@@ -97,7 +96,6 @@ Importing styles from an npm package with a relative path:
 You can also import CSS directly from a JavaScript file to control load order if you have the `ecmascript` package installed:
 
 ```js
-// foo.js
 import 'npm-package-name/stylesheets/styles.css';
 ```
 


### PR DESCRIPTION
Added comments at the head of snippets with a filename, so the reader knows the extension. Was a confusing mixture of less, js, and css. 

Instead of `foo.js/less`, could do `imports.` or `styles.`, `my-component.`, or full path, `client/imports.`

Removed the example of importing npm css from css, because it appears not to work (https://github.com/meteor/meteor/issues/6846)

