### PR TITLE
Update eslint install details

### DIFF
--- a/content/code-style.md
+++ b/content/code-style.md
@@ -90,8 +90,6 @@ To setup ESLint in your application, you can install the following [npm](https:/
 meteor npm install --save-dev eslint-config-airbnb eslint-plugin-import eslint-plugin-meteor eslint-plugin-react eslint-plugin-jsx-a11y eslint
 ```
 
-If you're not using React in your project you can omit `eslint-plugin-react` from the above command.
-
 > Meteor comes with npm bundled so that you can type meteor npm without worrying about installing it yourself. If you like, you can also use a globally installed npm command.
 
 You can also add a `eslintConfig` section to your `package.json` to specify that you'd like to use the Airbnb config, and to enable [ESLint-plugin-Meteor](https://github.com/dferber90/eslint-plugin-meteor). You can also setup any extra rules you want to change, as well as adding a lint npm command:

--- a/content/code-style.md
+++ b/content/code-style.md
@@ -87,8 +87,10 @@ Below, you can find directions for setting up automatic linting at many differen
 To setup ESLint in your application, you can install the following [npm](https://docs.npmjs.com/getting-started/what-is-npm) packages:
 
 ```
-meteor npm install --save-dev eslint eslint-plugin-react eslint-plugin-meteor eslint-config-airbnb
+meteor npm install --save-dev eslint-config-airbnb eslint-plugin-import eslint-plugin-meteor eslint-plugin-react eslint-plugin-jsx-a11y eslint
 ```
+
+If you're not using React in your project you can omit `eslint-plugin-react` from the above command.
 
 > Meteor comes with npm bundled so that you can type meteor npm without worrying about installing it yourself. If you like, you can also use a globally installed npm command.
 
@@ -106,15 +108,13 @@ You can also add a `eslintConfig` section to your `package.json` to specify that
       "meteor"
     ],
     "extends": [
-      "airbnb/base",
+      "airbnb",
       "plugin:meteor/recommended"
     ],
     "rules": {}
   }
 }
 ```
-
-Use `"airbnb/base"` for a normal ecmascript-based config and `"airbnb"` in a React project.
 
 To run the linter, you can now simply type:
 


### PR DESCRIPTION
The latest version of eslint-config-airbnb requires a different command to install it. Before merging this however there seems to be an issue with running `meteor npm run lint` that results in:

```
> guide-starter@ lint /Users/dave/Meteor/guide-starter
> eslint .

Property 'Symbol(Symbol.iterator)_9.kpf24hcf54su4n29' of object [object Map] is not a function
TypeError: Property 'Symbol(Symbol.iterator)_9.kpf24hcf54su4n29' of object [object Map] is not a function
    at EventEmitter.ProgramExit (/Users/dave/Meteor/guide-starter/node_modules/eslint-plugin-import/lib/rules/export.js:92:149)
    at EventEmitter.emit (events.js:117:20)
    at NodeEventGenerator.leaveNode (/Users/dave/Meteor/guide-starter/node_modules/eslint/lib/util/node-event-generator.js:49:22)
    at CodePathAnalyzer.leaveNode (/Users/dave/Meteor/guide-starter/node_modules/eslint/lib/code-path-analysis/code-path-analyzer.js:627:23)
    at CommentEventGenerator.leaveNode (/Users/dave/Meteor/guide-starter/node_modules/eslint/lib/util/comment-event-generator.js:110:23)
    at Controller.traverser.traverse.leave (/Users/dave/Meteor/guide-starter/node_modules/eslint/lib/eslint.js:889:36)
    at Controller.__execute (/Users/dave/Meteor/guide-starter/node_modules/estraverse/estraverse.js:397:31)
    at Controller.traverse (/Users/dave/Meteor/guide-starter/node_modules/estraverse/estraverse.js:491:28)
    at Controller.Traverser.controller.traverse (/Users/dave/Meteor/guide-starter/node_modules/eslint/lib/util/traverser.js:36:33)
    at EventEmitter.module.exports.api.verify (/Users/dave/Meteor/guide-starter/node_modules/eslint/lib/eslint.js:883:23)
```

However `npm run lint` works fine.