### PR TITLE
fixed boolean logic priority bug

### DIFF
--- a/content/security.md
+++ b/content/security.md
@@ -274,7 +274,7 @@ Meteor.publish('list', function (listId) {
 
   const list = Lists.findOne(listId);
 
-  if (! list.userId === this.userId) {
+  if (list.userId !== this.userId) {
     throw new Meteor.Error('list.unauthorized',
       'This list doesn\'t belong to you.');
   }


### PR DESCRIPTION
Thanks for submitting a PR! We'll try to look at it as soon as possible.

If you are adding significant new content, please take a moment to include an update to the [changelog](https://github.com/meteor/guide/blob/master/CHANGELOG.md) in your PR.

Use this field to describe your pull request.

There is a subtle difference between `(! a === b)` and `(a !== b)`.
For example `(! 2 === 3)` is false, while `(2 !== 3)` is true.