### PR TITLE
Update Testing chapter on publication-collector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ order: 1001
 description: A log of significant changes to the Meteor Guide.
 ---
 
+- 2016/05/22: Created new section "Testing publications" for separated `publication-collector` package (as [discussed here](https://github.com/meteor/todos/issues/119)).
 - 2016/05/05: Changed Build Section organization to separate Atmosphere and npm.  [Discussed here](https://github.com/meteor/guide/pull/390#issuecomment-212577341). [PR #410](https://github.com/meteor/guide/pull/410)
 - 2016/04/16: Switch order of Code Style and Application structure sections. [PR #383](https://github.com/meteor/guide/pull/383)
 - 2016/04/16: Added [Writing Packages - Creating an npm package](https://guide.meteor.com/writing-packages.html#creating-npm) and [Using Packages - Overriding packages - npm](https://guide.meteor.com/using-packages.html#npm-overriding). [PR #381](https://github.com/meteor/guide/pull/381)

--- a/content/testing.md
+++ b/content/testing.md
@@ -355,24 +355,27 @@ In the [unit test above](#simple-unit-test) we saw a very limited example of how
   - Alternatively, you can also use tools like [Sinon](http://sinonjs.org) to stub things directly, as we'll see for example in our [simple integration test](#simple-integration-test).
 
   - The [`hwillson:stub-collections`](https://atmospherejs.com/hwillson/stub-collections) package we mentioned [above](#mocking-the-database).
+  
+There's a lot of scope for better isolation and testing utilities.
 
-  - (Using another package from the example app) to isolate a publication, the `publication-collector` package:
+<h4 id="testing-publications">Testing publications</h4>
 
-    ```js
-    describe('lists.public', function () {
-      it('sends all public lists', function (done) {
-        // Allows us to look at the output of a publication without
-        // needing a client connection
-        const collector = new PublicationCollector();
-        collector.collect('lists.public', (collections) => {
-          chai.assert.equal(collections.Lists.length, 3);
-          done();
-        });
-      });
+Using the [`publication-collector` package](https://atmospherejs.com/johanbrook/publication-collector), you're able to test individual publication's output without needing to create a traditional subscription:
+
+```js
+describe('lists.public', function () {
+  it('sends all public lists', function (done) {
+    // Allows us to look at the output of a publication without
+    // needing a client connection
+    const collector = new PublicationCollector({userId: 'some-id'});
+
+    collector.collect('lists.public', (collections) => {
+      chai.assert.equal(collections.Lists.length, 3);
+      done();
     });
-    ```
-
-There's a lot of scope for better isolation and testing utilities (the two packages from the example app above could be improved greatly!). We encourage the community to take the lead on these.
+  });
+});
+```
 
 <h2 id="integration-testing">Integration testing</h2>
 

--- a/content/testing.md
+++ b/content/testing.md
@@ -360,22 +360,29 @@ There's a lot of scope for better isolation and testing utilities.
 
 <h4 id="testing-publications">Testing publications</h4>
 
-Using the [`publication-collector` package](https://atmospherejs.com/johanbrook/publication-collector), you're able to test individual publication's output without needing to create a traditional subscription:
+Using the [`johanbrook:publication-collector` package](https://atmospherejs.com/johanbrook/publication-collector), you're able to test individual publication's output without needing to create a traditional subscription:
 
 ```js
 describe('lists.public', function () {
   it('sends all public lists', function (done) {
-    // Allows us to look at the output of a publication without
-    // needing a client connection
+    // Set a user id that will be provided to the publish function as `this.userId`,
+    // in case you want to test authentication.
     const collector = new PublicationCollector({userId: 'some-id'});
-
+  
+    // Collect the data published from the `lists.public` publication.
     collector.collect('lists.public', (collections) => {
+      // `collections` is a dictionary with collection names as keys,
+      // and their published documents as values in an array.
+      // Here, documents from the collection 'Lists' are published.
+      chai.assert.typeOf(collections.Lists, 'array');
       chai.assert.equal(collections.Lists.length, 3);
       done();
     });
   });
 });
 ```
+
+Note that user documents – ones that you would normally query with `Meteor.users.find()` – will be available as the key `users` on the dictionary passed from a `PublicationCollector.collect()` call. See the [tests](https://github.com/johanbrook/meteor-publication-collector/blob/master/tests/publication-collector.test.js) in the package for more details.
 
 <h2 id="integration-testing">Integration testing</h2>
 


### PR DESCRIPTION
This patch puts info about testing publications in a separate `h4` heading, and linking to the newly separated package on Atmosphere.

- [x] Add new heading "Testing publications"
- [x] Add link to newly extracted `publication-collector` package.

***

- [x] If this is a significant change, update [CHANGELOG.md](https://github.com/meteor/guide/blob/master/CHANGELOG.md)
- [ ] Use `<h2 id="foo">` instead of `## Foo` for headers
- [x] Leave a blank line after each header