### PR TITLE
Fixed a typo in the CDN example code

### DIFF
--- a/content/deployment.md
+++ b/content/deployment.md
@@ -97,7 +97,7 @@ If you are hosting a webfont as part of your application and serving it via a CD
 import { WebApp } from 'meteor/webapp';
 
 WebApp.rawConnectHandlers.use(function(req, res, next) {
-  if (req._parsedUrl.pathname.match(/\.(ttf|ttc|otf|eot|woff|font\.css|css)$/) {
+  if (req._parsedUrl.pathname.match(/\.(ttf|ttc|otf|eot|woff|font\.css|css)$/)) {
     res.setHeader('Access-Control-Allow-Origin', /* your hostname, or just '*' */);
   }
   next();


### PR DESCRIPTION
<!--
🙌 Thanks for making this PR 😃
-->

TODO:

- [x] If this is a significant change, update [CHANGELOG.md](https://github.com/meteor/guide/blob/master/CHANGELOG.md)
- [x] Use `<h2 id="foo">` instead of `## Foo` for headers
- [x] Leave a blank line after each header

