### PR TITLE
removed redundant if

### DIFF
--- a/content/data-loading.md
+++ b/content/data-loading.md
@@ -582,9 +582,7 @@ Meteor.publish('polled-publication', function() {
         this.changed(COLLECTION_NAME, doc._id, doc);
       } else {
         publishedKeys[doc._id] = true;
-        if (publishedKeys[doc._id]) {
-          this.added(COLLECTION_NAME, doc._id, doc);
-        }
+        this.added(COLLECTION_NAME, doc._id, doc);
       }
     });
   };


### PR DESCRIPTION
<!--
🙌 Thanks for making this PR 😃
-->

TODO:

- [x] If this is a significant change, update [CHANGELOG.md](https://github.com/meteor/guide/blob/master/CHANGELOG.md)
- [x] Use `<h2 id="foo">` instead of `## Foo` for headers
- [x] Leave a blank line after each header

I removed an if which I believe was redundant. In case it was really necessary, and I missed it, then I would suggest to add a comment with explanation for it's existence.

Also, I'm not sure what (if any) exceptions can be thrown by `this.added(...)`, but perhaps it would be a better idea to move `publishedKeys[doc._id]=true` after the `this.added(...)`?