### PR TITLE
Change default to const to avoid linter errors.

### DIFF
--- a/content/methods.md
+++ b/content/methods.md
@@ -91,7 +91,7 @@ Here's some of the functionality an ideal Method would have:
 <h4 id="advanced-boilerplate-defining">Defining</h4>
 
 ```js
-export default updateText = {
+export const updateText = {
   name: 'todos.updateText',
 
   // Factor out validation so that it can be run independently (1)


### PR DESCRIPTION
Hi guys - see [this forum post for the issue](https://forums.meteor.com/t/meteor-guide-methods/19662/31). Changing `default` to `const` will help address this. Thanks!