### PR TITLE
Instruct ESLint to allow conditional imports

### DIFF
--- a/content/code-style.md
+++ b/content/code-style.md
@@ -89,7 +89,7 @@ Below, you can find directions for setting up automatic linting at many differen
 To setup ESLint in your application, you can install the following [npm](https://docs.npmjs.com/getting-started/what-is-npm) packages:
 
 ```
-meteor npm install --save-dev eslint-config-airbnb eslint-plugin-import eslint-plugin-meteor eslint-plugin-react eslint-plugin-jsx-a11y eslint-import-resolver-meteor eslint
+meteor npm install --save-dev babel-eslint eslint-config-airbnb eslint-plugin-import eslint-plugin-meteor eslint-plugin-react eslint-plugin-jsx-a11y eslint-import-resolver-meteor eslint
 ```
 
 > Meteor comes with npm bundled so that you can type meteor npm without worrying about installing it yourself. If you like, you can also use a globally installed npm command.
@@ -104,6 +104,10 @@ You can also add a `eslintConfig` section to your `package.json` to specify that
     "pretest": "npm run lint --silent"
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
+    "parserOptions": {
+      "allowImportExportEverywhere": true
+    },
     "plugins": [
       "meteor"
     ],


### PR DESCRIPTION
<!--
🙌 Thanks for making this PR 😃
-->

TODO:

- [x] If this is a significant change, update [CHANGELOG.md](https://github.com/meteor/guide/blob/master/CHANGELOG.md)
- [x] Use `<h2 id="foo">` instead of `## Foo` for headers
- [x] Leave a blank line after each header

Conditional imports as now enabled by Ben's changes in 1.3.3 and beyond cause the default configuration of ESLint to emit a syntax error and stop further analysis. 

Thankfully, the maintainers of babel-eslint, one of the parsers that works with ESLint, accepted a PR to allow us to fix this.

The changes to the ESLint setup in this commit simply enable that fix.