### PR TITLE
Update instructions for juliancwirko:postcss

### DIFF
--- a/content/build-tool.md
+++ b/content/build-tool.md
@@ -173,7 +173,7 @@ Then we can install any npm CSS processing packages that we'd like to use and re
 
 ```
 {
-  "devDependencies": {
+  "dependencies": {
     "autoprefixer": "^6.3.1"
   },
   "postcss": {


### PR DESCRIPTION
...to reflect changes in the meteor/todos app ( https://github.com/meteor/todos/commit/a127e3128fca6eee98a2476896243677a17a9adf )

Not sure if this constitutes a major change. I'd think not, but I suppose if people have been installing autoprefixer as a devDependency and are having issues, it could help to draw attention to the change. I also considered adding a note above the instructions such as:

"Note: a previous version of the guide mistakenly suggested adding autoprefixer as a devDependency. If you used a previous version of the guide and are having issues, please ensure autoprefixer is installed as a normal dependency(and don't forget to 'npm install')."

I've neither added the note, nor updated the changelog, but I'll be more than happy to update this PR however you see fit.