### PR TITLE
Typo in component name

### DIFF
--- a/content/react.md
+++ b/content/react.md
@@ -216,7 +216,7 @@ import { Lists } from '../../api/lists/lists.js';
 import { createContainer } from 'meteor/react-meteor-data';
 import ListPage from '../pages/ListPage.js';
 
-export default ListContainer = createContainer(({ params }) => {
+export default ListPageContainer = createContainer(({ params }) => {
   const { id } = params;
   const todosHandle = Meteor.subscribe('todos.inList', id);
   const loading = !todosHandle.ready();


### PR DESCRIPTION
<!--
🙌 Thanks for making this PR 😃
-->

TODO:

- [ ] If this is a significant change, update [CHANGELOG.md](https://github.com/meteor/guide/blob/master/CHANGELOG.md)
- [ ] Use `<h2 id="foo">` instead of `## Foo` for headers
- [ ] Leave a blank line after each header

I think ListContainer should be ListPageContainer according to the tutorial