### PR TITLE
(collections) remove unnecesery closing parentheses

### DIFF
--- a/content/collections.md
+++ b/content/collections.md
@@ -322,7 +322,7 @@ Migrations.add({
   version: 1,
   up() {
     Lists.find({todoCount: {$exists: false}}).forEach(list => {
-      const todoCount = Todos.find({listId: list._id})).count();
+      const todoCount = Todos.find({listId: list._id}).count();
       Lists.update(list._id, {$set: {todoCount}});
     });
   },


### PR DESCRIPTION
Changed:
`Todos.find({listId: list._id}))`
To:
 `Todos.find({listId: list._id})`