### PR TITLE
Added observed gotchas

### DIFF
--- a/content/1.4-migration.md
+++ b/content/1.4-migration.md
@@ -64,3 +64,44 @@ if (Meteor.isClient) {
 ```
 
 One place this is particularly useful is in [test files that are only intended to run on the client or the server](https://github.com/meteor/todos/commit/3963a65d96cd7ef235a95d5e3a331d6f0606f70f) &mdash; you can now use `import` wherever you like, without having to organize your tests in `client` or `server` directories.
+
+<h2 id="gotchas">Gotchas!</h2>
+Here is a list of observed gotchas...
+
+<h3 id="mongo-3_2-gotchas">Mongo 3.2</h3>
+
+If you are using [oplog tailing](https://github.com/meteor/docs/blob/version-NEXT/long-form/oplog-observe-driver.md) and you see a failed authentication you may need to upgrade to [SCRAM-SHA-1](https://docs.mongodb.com/manual/release-notes/3.0-scram/#upgrade-mongodb-cr-to-scram), essentially: `use admin, db.adminCommand({authSchemaUpgrade: 1});`.  You may need to delete and re-add your oplog reader user.
+
+<h3 id="node-gyp-gotchas">node-gyp</h3>
+
+Make sure this is installed so you can compile your node modules to native if necessary.  See [Install `node-gyp`](https://github.com/nodejs/node-gyp#installation)
+
+<h3 id="clear-out-oldstuff-gotchas">Clear out old stuff</h3>
+
+Try a `meteor reset` or better yet `rm -rf .meteor/local`.  Follow this with the [rebuild command](https://guide.meteor.com/1.4-migration.html#binary-packages-require-build-toolchain).
+
+<h3 id="npm-bcrypt-gotchas">npm-bcrypt</h3>
+
+You may run into this [`npm-bcrypt`](http://stackoverflow.com/questions/29340510/bcrypt-is-breaking-my-meteor-application-how-do-i-fix-it/29347616) problem
+
+<h3 id="debugger-gotcha">debugger statement issue</h3>
+If you have `debugger` statements in your code they will now hit the breakpoint even without a debugger attached.
+<h4>Old Behavior (prior to Meteor 1.4 with Node v0.10.46)</h4>
+
+Set `NODE_OPTIONS=--debug`<br>
+Sprinkle `debugger` statements in code<br>
+`meteor` command will start and run fine, skipping `debugger` statements
+
+<h4>New Behavior (Meteor 1.4 with Node v4.4.7)</h4>
+
+Set `NODE_OPTIONS=--debug`<br>
+Sprinkle `debugger` statements in code<br>
+`meteor` command will start will stop at first `debugger` statement waiting for a debugger to attach
+
+<h4>Comments:</h4>
+
+The old behavior was quite handy because when the `--debug-brk` flag was not used the code would blow past `debugger` statements unless a debugger was attached. Essentially, you could leave a few `debugger` statements in the startup code so that when the `--debug-brk` flag was used you could just hit continue from the initial breakpoint and it would stop before any init code.
+
+The new behavior may be even better, now you can put in `debugger` statements in the init code when you want to debug there and avoid the use of the `--debug-brk` flag altogether. `--debug-brk` is a pain because it starts debugging from the very beginning of the code load. And this would involve loading each package in debug mode which is very slow.
+
+So now debugging init code can be a much quicker as you can avoid loading all packages in debug mode. Thanks Node v4.4.7!


### PR DESCRIPTION
<!--
🙌 Thanks for making this PR 😃
-->

TODO:

- [N/A ] If this is a significant change, update [CHANGELOG.md](https://github.com/meteor/guide/blob/master/CHANGELOG.md)
- [X ] Use `<h2 id="foo">` instead of `## Foo` for headers
- [X ] Leave a blank line after each header

Hi @tmeasday, this is a list of gotchas I ran across while making v1.4 work.  @stubailo suggested I add [this ](https://forums.meteor.com/t/meteor-1-4-not-starting-due-to-debugger-statements/27109)to the migration guide, so I thought I would give it a shot and add all the issues I ran into.  Not sure this is a format or the way you would want to address any of this.  You are likely a better editor than I.

Also, I used `<h4>` headers without any IDs in one section...
