### PR TITLE
Add a note about the `replicaSet` argument

### DIFF
--- a/content/1.4-migration.md
+++ b/content/1.4-migration.md
@@ -39,6 +39,8 @@ Updating your database to 2.6 is generally pretty painless. Please consult the [
 
 > As of 1.4, you must ensure your `MONGO_OPLOG_URL` contains a `replicaSet` argument (see [the changelog](https://github.com/meteor/meteor/blob/devel/History.md#v14) and [the oplog documentation](https://github.com/meteor/docs/blob/master/long-form/oplog-observe-driver.md#oplogobservedriver-in-production)).
 
+> NOTE: Some MongoDB hosting providers may have a deployment setup that doesn't require you to use a `replicaSet` argument. For example, [Compose.io](https://www.compose.io/) has two types of deployments, MongoDB Classic and MongoDB+. The new MongoDB+ offering is a sharded setup and not a true replica set (despite the shard being implemented as a replica set) so it does not require the `replicaSet` parameter and Meteor will throw an error if you add it to your connection strings.
+
 > If you see a failed authentication you may need to upgrade to [SCRAM-SHA-1](https://docs.mongodb.com/manual/release-notes/3.0-scram/#upgrade-mongodb-cr-to-scram), essentially: `use admin, db.adminCommand({authSchemaUpgrade: 1});`.  You may need to delete and re-add your oplog reader user.
 
 <h3 id="debugger">Remove debugger statements</h3>


### PR DESCRIPTION
In some cases the `replicaSet` argument should be omitted in MongoDB connection strings.