### PR TITLE
Naming g++ as necessary C compiler on Linux

### DIFF
--- a/content/1.4-migration.md
+++ b/content/1.4-migration.md
@@ -25,7 +25,7 @@ In order for this rebuilding to work, you will need to install a basic compiler 
 
  - Windows users should install the [MS Build Tools](https://www.microsoft.com/en-us/download/details.aspx?id=48159).
 
- - Linux users should ensure they have Python 2.7, `make` and a C compiler installed.
+ - Linux users should ensure they have Python 2.7, `make` and a C compiler (g++) installed.
 
 To test that your compiler toolchain is installed and working properly, try installing any binary npm package in your application using `meteor npm`. For example, run `meteor npm install bcrypt` then `meteor node`, then try calling `require("bcrypt")` from the Node shell.
 


### PR DESCRIPTION
I had already gcc installed, but I had to install g++ to make it working. So, I suggest naming this compiler could help others.