### PR TITLE
Update CDN web font handling instructions

### DIFF
--- a/content/deployment.md
+++ b/content/deployment.md
@@ -101,7 +101,7 @@ If you are hosting a webfont as part of your application and serving it via a CD
 import { WebApp } from 'meteor/webapp';
 
 WebApp.rawConnectHandlers.use(function(req, res, next) {
-  if (req._parsedUrl.pathname.match(/\.(ttf|ttc|otf|eot|woff|font\.css|css)$/)) {
+  if (req._parsedUrl.pathname.match(/\.(ttf|ttc|otf|eot|woff|woff2|font\.css|css)$/)) {
     res.setHeader('Access-Control-Allow-Origin', /* your hostname, or just '*' */);
   }
   next();


### PR DESCRIPTION
Add woff2 to the list of supported extensions for webfonts.