### PR TITLE
give example how to use WebAppStartupTimeout

### DIFF
--- a/content/mobile.md
+++ b/content/mobile.md
@@ -275,6 +275,11 @@ To avoid this, we try to detect faulty versions and revert to the last known goo
 
 By default, the startup timeout is set to 20 seconds. If your app needs more time to startup (or considerably less), you can use [`App.setPreference`](http://docs.meteor.com/api/mobile-config.html#App-setPreference) to set `WebAppStartupTimeout` to another value.
 
+> Note that the value is set in milliseconds
+> ```js
+App.setPreference('WebAppStartupTimeout', 30000);
+```
+
 <h2 id="cordova-plugins">Native features with Cordova plugins</h2>
 
 Cordova comes with a plugin architecture that opens up access to features not usually available to web apps. Plugins are installable add-ons that contain both JavaScript and native code, which allows them to translate calls from your web app to platform-specific APIs.


### PR DESCRIPTION
Wanted to give an example that made it clear that the argument value should be in ms instead of seconds. The text implies you should pass in seconds but that is definitely not the case. There is no other place online that specifies it takes the argument in ms and there are some forum posts and github issues that reflect this confusion.

An alternative would be to change the line above to `the startup time is set to 20,000 milliseconds` which would **imply** that if you were to change the value it would be in ms instead of seconds although that may still not be explicit enough
