### PR TITLE
note added to testing section

### DIFF
--- a/content/testing.md
+++ b/content/testing.md
@@ -102,7 +102,7 @@ describe('my module', function () {
 })
 ```
 
-Note that arrow function use with Mocha [is discouraged](http://mochajs.org/#arrow-functions).
+Note that arrow function use with Mocha [is discouraged](http://mochajs.org/#arrow-functions). Also 'my module' must equal your test file name, otherwise your tests will not be seen. So for `todos-item.test.js` 'my module' will be `todos-item`.
 
 <h2 id="test-data">Test data</h2>
 


### PR DESCRIPTION
<!--
🙌 Thanks for making this PR 😃
-->

TODO:

- [x] If this is a significant change, update [CHANGELOG.md](https://github.com/meteor/guide/blob/master/CHANGELOG.md)
- [x] Use `<h2 id="foo">` instead of `## Foo` for headers
- [x] Leave a blank line after each header

This had me stumped while using practical-meteor:mocha until I realised what was going on. I do not see this restriction when running mocha tests with an npm package I have authored, so in that case it might be a bug as I don’t believe that the file name should be so tightly coupled to the test suite name. Please advise.