### PR TITLE
Use `npm start` to start the Hexo server

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,11 +57,11 @@ Render multiple items in your template with `{% raw %}{{#each}}{% endraw %}`
 
 ### Running the static site generator locally
 
-The site is built using hexo, a static site generator. You'll need to `npm install -g hexo-cli`, then
+The site is built using hexo, a static site generator.  To run it locally, perform the following steps:
 
 ```
 git submodule update --init --recursive
 cd site
 npm install
-hexo server
+npm start
 ```

--- a/site/package.json
+++ b/site/package.json
@@ -20,7 +20,8 @@
     "hexo-server": "^0.1.2"
   },
   "scripts": {
-    "deploy": "hexo-s3-deploy"
+    "deploy": "hexo-s3-deploy",
+    "start": "hexo server"
   },
   "devDependencies": {
     "hexo-s3-deploy": "^1.1.1"


### PR DESCRIPTION
With this change, it's no longer necessary to install `hexo-cli` globally and makes the `guide` more consistent with the `docs` repo.  The old method will still work fine for those using that method.

/cc @tmeasday @lorensr 