### PR TITLE
Remove note about peer dependencies testing limitation

### DIFF
--- a/content/writing-atmosphere-packages.md
+++ b/content/writing-atmosphere-packages.md
@@ -256,12 +256,6 @@ From within your test entry point, you can import other files as you would in th
 
 You can read more about testing in Meteor in the [Testing article](testing.html).
 
-<h3 id="testing-with-peer-dependencies">Testing with peer npm dependencies</h3>
-
-If your package makes use of [peer npm dependencies](#peer-npm-dependencies), you cannot currently use `test-packages` to write package tests (as the dependencies will not be included in the special test app).
-
-To work around this, you can create a "scaffolding" test application, which is a simple app which simply includes the package and uses standard [tests](testing.html) to run tests against the package. You can see examples of these kind of scaffold test apps in the [React packages repository](https://github.com/meteor/react-packages/tree/devel/tests).
-
 <h2 id="publishing-atmosphere">Publishing your package</h2>
 
 To publish your package to Atmosphere, run [`meteor publish`](http://docs.meteor.com/#/full/meteorpublish) from the package directory. To publish a package the package name must follow the format of `username:my-package` and the package must contain a [SemVer version number](#version-constraints).


### PR DESCRIPTION
As found in meteor/meteor#7500, it is no longer true that you need to have a separate scaffolding test application to accomplish this.