### PR TITLE
Added Docker section within Deployment and Monitoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ order: 1001
 description: A log of significant changes to the Meteor Guide.
 ---
 
+- 2016/10/18: Added Docker section within Deployment and Monitoring.
 - 2016/07/02: Created new section in ui-ux on use of i18n with React.
 - 2016/05/28: Created new section "A simple React unit test" [PR #466](https://github.com/meteor/guide/pull/466).
 - 2016/05/22: Created new section "Testing publications" for separated `publication-collector` package (as [discussed here](https://github.com/meteor/todos/issues/119)).

--- a/content/deployment.md
+++ b/content/deployment.md
@@ -166,6 +166,17 @@ Meteor Up has multiple projects so select what is best for your project:
 
 For further assistance, consult the documentation for the option you select.
 
+<h3 id="docker">Docker</h3>
+
+To orchestrate your own container-based deployment there are existing base images to consider before rolling your own:
+
+ - **[jshimko/meteor-launchpad](https://github.com/jshimko/meteor-launchpad)**
+ - [meteorhacks/meteord](https://github.com/kadirahq/meteord)
+ - [chriswessels/meteor-tupperware](https://github.com/chriswessels/meteor-tupperware)
+
+
+_The recommendation above is primarily based on current state of maintenance to address upstream security vulnerabilities. Review the Dockerfiles and build scripts to make your own assessment._
+
 <h3 id="custom-deployment">Custom deployment</h3>
 
 If you want to figure out your hosting solution completely from scratch, the Meteor tool has a command `meteor build` that creates a deployment bundle that contains a plain Node.js application. Any npm dependencies must be installed before issuing the `meteor build` command to be included in the bundle. You can host this application wherever you like and there are many options in terms of how you set it up and configure it.


### PR DESCRIPTION
I wanted to contribute the outcome of a few hours of research into the current state of available base Docker images for Meteor. While MeteorD has been the most popular due to it's importance to MUP users, it's got a [bug right now](https://github.com/kadirahq/meteord/pull/11/) and is still [installing the insecure node 4.4.7](https://github.com/kadirahq/meteord/blob/master/base/scripts/lib/install_node.sh#L3) despite open PRs ready to merge.

@jshimko [suggested his image](https://github.com/kadirahq/meteord/pull/11#issuecomment-254251571)

> I use and maintain it regularly and I'm always open to contributions

meteor-tupperware is no longer actively supported by @chriswessels, however I feel there's still value in providing a link so that a fork could establish since this solution did have a nice bootstrapping script and provided inspiration for slimming the original MeteorD image down.

cc @mnmtanish (kadirahq)
