### PR TITLE
Small capitalisation inconsistency

### DIFF
--- a/content/collections.md
+++ b/content/collections.md
@@ -28,7 +28,7 @@ In this article, we'll look closely at how collections work in various places in
 When you create a collection on the server:
 
 ```js
-Todos = new Mongo.Collection('Todos');
+Todos = new Mongo.Collection('todos');
 ```
 
 You are creating a collection within MongoDB, and an interface to that collection to be used on the server. It's a fairly straightforward layer on top of the underlying Node MongoDB driver, but with a synchronous API:
@@ -47,7 +47,7 @@ console.log(todo);
 On the client, when you write the same line:
 
 ```js
-Todos = new Mongo.Collection('Todos');
+Todos = new Mongo.Collection('todos');
 ```
 
 It does something totally different!


### PR DESCRIPTION
<!--
🙌 Thanks for making this PR 😃
-->

Small inconsistency with the Mongo collection naming conventions as can be seen here: https://docs.mongodb.com/v3.2/reference/method/db.createCollection/

And discussed here:
https://forums.meteor.com/t/collections-and-schemas/19660/37

The line as it currently stands would create a capitalised collection "Todos" instead of the lowercase "todos" as the Mongo documentation suggests.

I think it makes sense to maintain consistency between the Meteor and MongoDB documentations