### PR TITLE
Update security.md - add isServer clause

### DIFF
--- a/content/security.md
+++ b/content/security.md
@@ -194,7 +194,7 @@ if (Meteor.isServer) {
     // Rate limit per connection ID
     connectionId() { return true; }
   }, 5, 1000);
- }
+}
 ```
 
 This will make every Method only callable 5 times per second per connection. This is a rate limit that shouldn't be noticeable by the user at all, but will prevent a malicious script from totally flooding the server with requests. You will need to tune the limit parameters to match your app's needs.

--- a/content/security.md
+++ b/content/security.md
@@ -184,14 +184,17 @@ const LISTS_METHODS = _.pluck([
 ], 'name');
 
 // Only allow 5 list operations per connection per second
-DDPRateLimiter.addRule({
-  name(name) {
-    return _.contains(LISTS_METHODS, name);
-  },
 
-  // Rate limit per connection ID
-  connectionId() { return true; }
-}, 5, 1000);
+if (Meteor.isServer) {
+  DDPRateLimiter.addRule({
+    name(name) {
+      return _.contains(LISTS_METHODS, name);
+    },
+
+    // Rate limit per connection ID
+    connectionId() { return true; }
+  }, 5, 1000);
+ }
 ```
 
 This will make every Method only callable 5 times per second per connection. This is a rate limit that shouldn't be noticeable by the user at all, but will prevent a malicious script from totally flooding the server with requests. You will need to tune the limit parameters to match your app's needs.


### PR DESCRIPTION
I had trouble with DDP-rate-limiter until I came across Adriano P's answer under the title "Meteor - DDPRateLimiter" on stackoverflow and realized that I should probably try putting an isServer clause around my rules (which resided in my lib folder). And sure enough, I stopped getting a console error saying that " DDPRateLimiter is not defined."

<!--
🙌 Thanks for making this PR 😃
-->

TODO:

- [ ] If this is a significant change, update [CHANGELOG.md](https://github.com/meteor/guide/blob/master/CHANGELOG.md)
- [ ] Use `<h2 id="foo">` instead of `## Foo` for headers
- [ ] Leave a blank line after each header
