### PR TITLE
Testing: Replace `factory` to `dburles:factory`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ order: 1001
 description: A log of significant changes to the Meteor Guide.
 ---
 
+- 2017/01/04: Changed "Testing" section to reference `dburles:factory` in the same spirit as the `meteor/todos` app [PR #598](https://github.com/meteor/guide/pull/598)
 - 2016/07/02: Created new section in ui-ux on use of i18n with React.
 - 2016/05/28: Created new section "A simple React unit test" [PR #466](https://github.com/meteor/guide/pull/466).
 - 2016/05/22: Created new section "Testing publications" for separated `publication-collector` package (as [discussed here](https://github.com/meteor/todos/issues/119)).

--- a/content/testing.md
+++ b/content/testing.md
@@ -238,10 +238,11 @@ A simple example of a reusable component to test is the [`Todos_item`](https://g
 /* eslint-env mocha */
 /* eslint-disable func-names, prefer-arrow-callback */
 
-import { Factory } from 'meteor/factory';
+import { Factory } from 'meteor/dburles:factory';
 import { chai } from 'meteor/practicalmeteor:chai';
 import { Template } from 'meteor/templating';
 import { $ } from 'meteor/jquery';
+import { Todos } from '../../../api/todos/todos';
 
 
 import { withRenderedTemplate } from '../../test-helpers.js';
@@ -259,7 +260,7 @@ describe('Todos_item', function () {
   it('renders correctly with simple data', function () {
     const todo = Factory.build('todo', { checked: false });
     const data = {
-      todo,
+      todo: Todos._transform(todo),
       onEditingChange: () => 0,
     };
 
@@ -322,7 +323,7 @@ We can use the [Factory package's](#test-data) `.build()` API to create a test d
 We can also apply the same structure to testing React components and recommend the [Enzyme](https://github.com/airbnb/enzyme) package, which simulates a React component's environment and allows you to query it using CSS selectors. A larger suite of tests is available in the [react branch of the Todos app](https://github.com/meteor/todos/tree/react), but let's look at a simple example for now:
 
 ```js
-import { Factory } from 'meteor/factory';
+import { Factory } from 'meteor/dburles:factory';
 import React from 'react';
 import { shallow } from 'enzyme';
 import { chai } from 'meteor/practicalmeteor:chai';
@@ -343,7 +344,7 @@ describe('TodoItem', () => {
 The test is slightly simpler than the Blaze version above because the React sample app is not internationalized. Otherwise, it's conceptually identical. We use Enzyme's `shallow` function to render the `TodoItem` component, and the resulting object to query the document, and also to simulate user interactions. And here's an example of simulating a user checking the todo item:
 
 ```js
-import { Factory } from 'meteor/factory';
+import { Factory } from 'meteor/dburles:factory';
 import React from 'react';
 import { shallow } from 'enzyme';
 import { sinon } from 'meteor/practicalmeteor:sinon';
@@ -459,7 +460,7 @@ In the [Todos](https://github.com/meteor/todos) example app, we have an integrat
 /* eslint-disable func-names, prefer-arrow-callback */
 
 import { Meteor } from 'meteor/meteor';
-import { Factory } from 'meteor/factory';
+import { Factory } from 'meteor/dburles:factory';
 import { Random } from 'meteor/random';
 import { chai } from 'meteor/practicalmeteor:chai';
 import StubCollections from 'meteor/hwillson:stub-collections';
@@ -628,7 +629,7 @@ Similar to the way we cleared the database using a method in the `beforeEach` in
 // ensuring the method is always available
 
 import { Meteor } from 'meteor/meteor';
-import { Factory } from 'meteor/factory';
+import { Factory } from 'meteor/dburles:factory';
 import { resetDatabase } from 'meteor/xolvio:cleaner';
 import { Random } from 'meteor/random';
 import { _ } from 'meteor/underscore';


### PR DESCRIPTION
In the testing section of the guide (amongst others), the guide references the Meteor "Todos" app: https://github.com/meteor/todos

Previously, `factory` was a locally forked Meteor package within the Todos repo which was a fork of `dburles:factory` with (minimal) tweaks.  See discussion in:

* meteor/todos#193
* meteor/todos#96

With the landing of meteor/todos#202, the Todos application now utilizes `dburles:factory`.  This commit gives the same treatment as that PR provided to `meteor/todos` (https://github.com/meteor/todos/pull/202/files).

Closes meteor/guide#576

/cc @hwillson @dburles