### PR TITLE
Updated link to Meteoric (Meteor + Blaze)

### DIFF
--- a/content/ui-ux.md
+++ b/content/ui-ux.md
@@ -42,7 +42,7 @@ Meteor officially supports three user interface (UI) rendering libraries, [Blaze
 - **Cordova**
   - All three libraries work fine in a Cordova web view, and you can use mobile CSS libraries like Ionic's CSS with any view library.
   - The most advanced mobile web framework is [Ionic 2](http://ionicframework.com/docs/v2/), which uses Angular 2.
-  - Ionic 1 uses Angular 1, but there are also [Blaze](http://meteoric-doc.com/) and [React](http://reactionic.github.io/) ports.
+  - Ionic 1 uses Angular 1, but there are also [Blaze](http://meteoric.github.io//) and [React](http://reactionic.github.io/) ports.
   - Another good option is [Onsen UI](https://onsen.io/v2/), which includes a [React version](https://onsen.io/v2/docs/guide/react/).
 - **Native**
   - You can connect any native iOS or Android app to a Meteor server via [DDP](https://www.meteor.com/ddp). For iOS, use the [`meteor-ios`](https://github.com/martijnwalraven/meteor-ios) framework.


### PR DESCRIPTION
The previous link to meteoric framework was deprecated. Just updated the link to point to the correct location (http://meteoric.github.io/).
