### PR TITLE
Removing list from the returned values

### DIFF
--- a/content/react.md
+++ b/content/react.md
@@ -222,7 +222,6 @@ export default ListPageContainer = createContainer(({ id }) => {
   const listExists = !loading && !!list;
   return {
     loading,
-    list,
     listExists,
     todos: listExists ? list.todos().fetch() : [],
   };


### PR DESCRIPTION
Removing list from the returned values because it raises this
error : '
  Warning: you are returning a Mongo cursor from getMeteorData.
  This value will not be reactive. You probably want to call `.fetch()`
  on the cursor before returning it.'

<!--
🙌 Thanks for making this PR 😃
-->

TODO:

- [ ] If this is a significant change, update [CHANGELOG.md](https://github.com/meteor/guide/blob/master/CHANGELOG.md)
- [ ] Use `<h2 id="foo">` instead of `## Foo` for headers
- [ ] Leave a blank line after each header
