### PR TITLE
Add missing = to meteor build command

### DIFF
--- a/content/mobile.md
+++ b/content/mobile.md
@@ -538,7 +538,7 @@ If you need to customize configuration files, a workaround is to create a dummy 
 
 <h3 id="building-for-production">Building for production</h3>
 
-Use `meteor build <build-output-directory> --server <host>:<port>` to build your app for production.
+Use `meteor build <build-output-directory> --server=<host>:<port>` to build your app for production.
 
 The `<host>` and `<port>` should be the address of the server you want your app to connect to.
 


### PR DESCRIPTION
Add `=` build command to be consistent and match output of `meteor help build` which is `--server=https://example.com:443`

<!--
🙌 Thanks for making this PR 😃
-->

TODO:

- [ ] If this is a significant change, update [CHANGELOG.md](https://github.com/meteor/guide/blob/master/CHANGELOG.md)
- [ ] Use `<h2 id="foo">` instead of `## Foo` for headers
- [ ] Leave a blank line after each header
