### PR TITLE
Modify script lint

### DIFF
--- a/content/code-style.md
+++ b/content/code-style.md
@@ -99,7 +99,7 @@ You can also add a `eslintConfig` section to your `package.json` to specify that
 {
   ...
   "scripts": {
-    "lint": "eslint .",
+    "lint": "eslint .;exit 0",
     "pretest": "npm run lint --silent"
   },
   "eslintConfig": {


### PR DESCRIPTION
An error occurred when the *lint* script is launched.
Adds `exit 0` for a proper stop of script.

<!--
🙌 Thanks for making this PR 😃
-->

TODO:

- [x] If this is a significant change, update [CHANGELOG.md](https://github.com/meteor/guide/blob/master/CHANGELOG.md)
- [x] Use `<h2 id="foo">` instead of `## Foo` for headers
- [x] Leave a blank line after each header
