### PR TITLE
Need to ensure default profile hook still runs

### DIFF
--- a/content/accounts.md
+++ b/content/accounts.md
@@ -576,6 +576,11 @@ Accounts.onCreateUser((options, user) => {
   const { first_name, last_name } = user.services.facebook;
   user.initials = first_name[0].toUpperCase() + last_name[0].toUpperCase();
 
+  // We still want the default hook's 'profile' behavior.
+  if (options.profile) {
+    user.profile = options.profile;
+  }
+  
   // Don't forget to return the new user object at the end!
   return user;
 });


### PR DESCRIPTION
If you don't set the profile from the options then you lose the default hook behaviour for the profile. For instance if a user signs up via Facebook then their profile should have a name field set as their name on Facebook, but if you don't have the code I just added then there will not be a profile at all. 
http://docs.meteor.com/api/accounts-multi.html#AccountsServer-onCreateUser

<!--
🙌 Thanks for making this PR 😃
-->

TODO:

- [ ] If this is a significant change, update [CHANGELOG.md](https://github.com/meteor/guide/blob/master/CHANGELOG.md)
- [ ] Use `<h2 id="foo">` instead of `## Foo` for headers
- [ ] Leave a blank line after each header
