### PR TITLE
Remove mention of react-addons-pure-render-mixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ order: 1001
 description: A log of significant changes to the Meteor Guide.
 ---
 
+- 2017/10/28: Removed mention of `react-addons-pure-render-mixin` package from "Using Meteor's data system" section as it is no longer needed.
 - 2017/09/08: Updated "Using Meteor's data system" section to describe the new `withTracker` function as it now replaces `createContainer`.
 - 2017/03/22: Added Docker section within Deployment and Monitoring.
 - 2017/03/05: Updated "Testing" to use the replacement `dispatch:mocha` package instead of the previous suggestions from `dispatch:*`. [PR#618](https://github.com/meteor/guide/pull/618) [PR#614](https://github.com/meteor/guide/pull/614)

--- a/content/react.md
+++ b/content/react.md
@@ -184,10 +184,9 @@ To integrate the two systems, we've developed a [`react-meteor-data`](https://at
 
 > The `withTracker` function now replaces the previous function `createContainer`, however it remains as part of the package for backwards compatibility.
 
-To use data from a Meteor collection inside a React component, install [`react-meteor-data`](https://atmospherejs.com/meteor/react-meteor-data) alongside a NPM package it utilizes, [`react-addons-pure-render-mixin`](https://www.npmjs.com/package/react-addons-pure-render-mixin):
+To use data from a Meteor collection inside a React component, install [`react-meteor-data`](https://atmospherejs.com/meteor/react-meteor-data):
 
 ```sh
-meteor npm install --save react-addons-pure-render-mixin
 meteor add react-meteor-data
 ```
 


### PR DESCRIPTION
Remove mentions of react-addons-pure-render-mixin which is [no longer used](https://github.com/meteor/react-packages/issues/239) from React > Using Meteor's data system > using withTracker

<!--
🙌 Thanks for making this PR 😃
-->

TODO:

- [x] If this is a significant change, update [CHANGELOG.md](https://github.com/meteor/guide/blob/master/CHANGELOG.md)
- [x] Use `<h2 id="foo">` instead of `## Foo` for headers
- [x] Leave a blank line after each header
