### PR TITLE
Remove refs to Kadira

### DIFF
--- a/content/deployment.md
+++ b/content/deployment.md
@@ -10,7 +10,7 @@ After reading this guide, you'll know:
 2. How to deploy to some common Meteor hosting environments.
 3. How to design a deployment process to make sure your application's quality is maintained.
 4. How to monitor user behavior with analytics tools.
-5. How to monitor your application with Kadira.
+5. How to monitor your application.
 6. How to make sure your site is discoverable by search engines.
 
 <h2 id="deploying">Deploying Meteor Applications</h2>
@@ -46,7 +46,7 @@ There are two main ways to configure your application outside of the code of the
 
 Settings should be used to set environment (i.e. staging vs production) specific things, like the access token and secret used to connect to Google. These settings will not change between any given process running your application in the given environment.
 
-Environment variables are used to set process specific things, which could conceivably change for different instances of your application's processes. For instance, you can set a different `KADIRA_OPTIONS_HOSTNAME` for each process to ensure that [kadira](#kadira) logs timings with useful hostnames.
+Environment variables are used to set process specific things, which could conceivably change for different instances of your application's processes. A list of environment variables can be found [here](https://docs.meteor.com/environment-variables.html).
 
 A final note on storing these settings: It's not a good idea to store settings the same repository where you keep your app code. Read about good places to put your settings in the [Security article](security.html#api-keys).
 

--- a/content/deployment.md
+++ b/content/deployment.md
@@ -46,7 +46,7 @@ There are two main ways to configure your application outside of the code of the
 
 Settings should be used to set environment (i.e. staging vs production) specific things, like the access token and secret used to connect to Google. These settings will not change between any given process running your application in the given environment.
 
-Environment variables are used to set process specific things, which could conceivably change for different instances of your application's processes. A list of environment variables can be found [here](https://docs.meteor.com/environment-variables.html).
+Environment variables are used to set process-specific things, which could conceivably change for different instances of your application's processes. A list of environment variables can be found [here](https://docs.meteor.com/environment-variables.html).
 
 A final note on storing these settings: It's not a good idea to store settings the same repository where you keep your app code. Read about good places to put your settings in the [Security article](security.html#api-keys).
 


### PR DESCRIPTION
I generalized "how to monitor your application" so the line doesn't need to be changed in the future. I also replaced the KADIRA_OPTIONS_HOSTNAME reference with a link to the environment variables Meteor uses.

