### PR TITLE
Fix typo in 1.6 migration guide.

### DIFF
--- a/content/1.6-migration.md
+++ b/content/1.6-migration.md
@@ -18,7 +18,7 @@ If you're migrating from a version of Meteor older than Meteor 1.5, there may be
 
 <h3 id="node-breaking-changes">Node.js Breaking Changes</h3>
 
-The most significant update in Meteor 1.6 is the upgrade of the underlying Node.js version which Meteor relies on.  While Meteor itself has made the appropriate changes, any core Node.js module usage within applications is subject to the breaking changes outlined by the Node.js change logs below which, when compbined, cover the transition from Node.js 4 to 8:
+The most significant update in Meteor 1.6 is the upgrade of the underlying Node.js version which Meteor relies on.  While Meteor itself has made the appropriate changes, any core Node.js module usage within applications is subject to the breaking changes outlined by the Node.js change logs below which, when combined, cover the transition from Node.js 4 to 8:
 
 * [Breaking changes between v4 and v6](https://github.com/nodejs/node/wiki/Breaking-changes-between-v4-LTS-and-v6-LTS).
 * [Breaking changes between v6 and v7](https://github.com/nodejs/node/wiki/Breaking-changes-between-v6-and-v7).


### PR DESCRIPTION
Just a small typo fix.