### PR TITLE
Revised Windows install instructions

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -20,7 +20,11 @@ Meteor is a full-stack JavaScript platform for developing modern web and mobile 
 
 Meteor supports [OS X, Windows, and Linux](https://www.meteor.com/install).
 
-On Windows?  [Download the official Meteor installer here](https://install.meteor.com/windows).
+On Windows?  First install [Chocolatey](https://chocolatey.org/), then run this command using and Administrator command prompt:
+
+```bash
+choco install meteor
+```
 
 On OS X or Linux?  Install the latest official Meteor release from your terminal:
 

--- a/content/index.md
+++ b/content/index.md
@@ -20,7 +20,7 @@ Meteor is a full-stack JavaScript platform for developing modern web and mobile 
 
 Meteor supports [OS X, Windows, and Linux](https://www.meteor.com/install).
 
-On Windows?  First install [Chocolatey](https://chocolatey.org/), then run this command using and Administrator command prompt:
+On Windows?  First install [Chocolatey](https://chocolatey.org/), then run this command using an Administrator command prompt:
 
 ```bash
 choco install meteor


### PR DESCRIPTION
The current version of Meteor doesn't use the installer, it has switched to Chocolatey. I modified the instructions to be congruent with the install instructions [here](https://www.meteor.com/install)

<!--
🙌 Thanks for making this PR 😃
-->

TODO:

- [ ] If this is a significant change, update [CHANGELOG.md](https://github.com/meteor/guide/blob/master/CHANGELOG.md)
- [ ] Use `<h2 id="foo">` instead of `## Foo` for headers
- [ ] Leave a blank line after each header
