### PR TITLE
Corrected importing of ReactiveVar

### DIFF
--- a/content/ui-ux.md
+++ b/content/ui-ux.md
@@ -253,7 +253,7 @@ To set and change the language that a user is seeing, you should call `TAPi18n.s
 export const CurrentLanguage = new ReactiveVar('en');
 
 
-import CurrentLanguage from '../stores/current-language.js';
+import { CurrentLanguage } from '../stores/current-language.js';
 TAPi18n.setLanguage(() => {
   CurrentLanguage.get();
 });


### PR DESCRIPTION
While trying out some personal code based on this example, I found out that the correct way of importing a ReactiveVar is using curly braces around it. not without, as the docs suggest in the modified example.
