### PR TITLE
Fix broken link to API docs' command line section

### DIFF
--- a/content/build-tool.md
+++ b/content/build-tool.md
@@ -4,7 +4,7 @@ description: How to use Meteor's build system to compile your app.
 discourseTopicId: 19669
 ---
 
-The Meteor build system is the actual command line tool that you get when you install Meteor. You run it by typing the `meteor` command in your terminal, possibly followed by a set of arguments. Read the [docs about the command line tool](http://docs.meteor.com/#/full/commandline) or type `meteor help` in your terminal to learn about all of the commands.
+The Meteor build system is the actual command line tool that you get when you install Meteor. You run it by typing the `meteor` command in your terminal, possibly followed by a set of arguments. Read the [docs about the command line tool](https://docs.meteor.com/commandline.html) or type `meteor help` in your terminal to learn about all of the commands.
 
 <h2 id="what-it-does">What does it do?</h2>
 


### PR DESCRIPTION
Just stumbled over this issue when reading the guide about build tool and found a broken link to the command line tool. Replaced the old with the actual link.