### PR TITLE
Change `content_root` to correct docs source path.

### DIFF
--- a/site/_config.yml
+++ b/site/_config.yml
@@ -6,6 +6,7 @@
 title: Meteor Guide
 subtitle: The Official Guide
 github_repo: meteor/guide
+content_root: content
 versions:
   - '1.6'
   - '1.5'


### PR DESCRIPTION
This should correct the "Edit on GitHub" buttons being broken, as
reported in meteor/guide#714.

Fixes: meteor/guide#714