### PR TITLE
Add warning to the use of the Post CSS package

### DIFF
--- a/content/build-tool.md
+++ b/content/build-tool.md
@@ -186,7 +186,7 @@ Currently, Meteor doesn't have a separate build step for post-processing CSS, so
 
 <h3 id="juliancwirko-postcss">juliancwirko:postcss</h3>
 
->Note: This package is no longer actively maintained, compatibility with newer versions of Meteor is not guaranteed. 
+>Note: This package is no longer actively maintained, therefore compatibility with newer versions of Meteor is not guaranteed. If you encouter problems with this, please let us know by [opening an issue on the Guide](https://github.com/meteor/guide/issues).
 
 Use the package [juliancwirko:postcss](https://atmospherejs.com/juliancwirko/postcss) to your app to enable PostCSS for your Meteor app. To do so, we remove the standard CSS minifier and replace it with the postcss package:
 

--- a/content/build-tool.md
+++ b/content/build-tool.md
@@ -186,6 +186,8 @@ Currently, Meteor doesn't have a separate build step for post-processing CSS, so
 
 <h3 id="juliancwirko-postcss">juliancwirko:postcss</h3>
 
+>Note: This package is no longer actively maintained, compatibility with newer versions of Meteor is not guaranteed. 
+
 Use the package [juliancwirko:postcss](https://atmospherejs.com/juliancwirko/postcss) to your app to enable PostCSS for your Meteor app. To do so, we remove the standard CSS minifier and replace it with the postcss package:
 
 ```


### PR DESCRIPTION
Adds warning to guide for the use juliancwirko:postcss package as its no longer actively maintained. Partially addresses https://github.com/meteor/guide/issues/668.