### PR TITLE
Replace Stylus Package Recommendation

### DIFF
--- a/content/build-tool.md
+++ b/content/build-tool.md
@@ -174,7 +174,7 @@ Less is maintained as a [Meteor core package called `less`](https://atmospherejs
 
 <h3 id="stylus">Stylus</h3>
 
-Stylus is maintained as a [Meteor core package called `stylus`](https://atmospherejs.com/meteor/stylus).
+The best Stylus build plugin for Meteor is [coagmano:stylus](https://atmospherejs.com/coagmano/stylus)
 
 <h2 id="postcss">PostCSS and Autoprefixer</h2>
 


### PR DESCRIPTION
The Stylus package has been deprecated. This change makes coagmano stylus package the recommended community package. 

