### PR TITLE
Document how to properly handle multiple subscriptions

### DIFF
--- a/content/data-loading.md
+++ b/content/data-loading.md
@@ -181,7 +181,7 @@ Tracker.autorun(() => {
 });
 ```
 
-If you're subscribing to multiple publications, no need to assign each handle to a variable. A proper way to do this would be to call `Meteor.subscribe` in an array and use [`every`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/every) on their handle to determine if they're ready:
+If you're subscribing to multiple publications, you can create an array of handles and use [`every`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/every) to determine if all are ready:
 
 ```js
 const handles = [

--- a/content/data-loading.md
+++ b/content/data-loading.md
@@ -177,7 +177,21 @@ To find that out, `Meteor.subscribe()` and (`this.subscribe()` in Blaze componen
 const handle = Meteor.subscribe('lists.public');
 Tracker.autorun(() => {
   const isReady = handle.ready();
-  console.log(`Handle is ${isReady ? 'ready' : 'not ready'}`);  
+  console.log(`Handle is ${isReady ? 'ready' : 'not ready'}`);
+});
+```
+
+If you're subscribing to multiple publications, no need to assign each handle to a variable. A proper way to do this would be to call `Meteor.subscribe` in an array and use [`every`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/every) on their handle to determine if they're ready:
+
+```js
+const handles = [
+  Meteor.subscribe('lists.public'),
+  Meteor.subscribe('todos.inList'),
+];
+
+Tracker.autorun(() => {
+  const areReady = handles.every(handle => handle.ready());
+  console.log(`Handles are ${areReady ? 'ready' : 'not ready'}`);
 });
 ```
 

--- a/content/react.md
+++ b/content/react.md
@@ -237,7 +237,7 @@ export default ListPageContainer = withTracker(({ id }) => {
 })(ListPage);
 ```
 
-If you're subscribing to multiple publications, no need to assign each handle to a variable. A proper way to do this would be to call `Meteor.subscribe` in an array and use [`some`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/some) on their handle to determine if they're loading:
+If you're subscribing to multiple publications, you can create an array of handles and use [`some`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/some) to determine if any is loading:
 
 ```js
 export default withTracker(({ id }) => {

--- a/content/react.md
+++ b/content/react.md
@@ -237,6 +237,21 @@ export default ListPageContainer = withTracker(({ id }) => {
 })(ListPage);
 ```
 
+If you're subscribing to multiple publications, no need to assign each handle to a variable. A proper way to do this would be to call `Meteor.subscribe` in an array and use [`some`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/some) on their handle to determine if they're loading:
+
+```js
+export default withTracker(({ id }) => {
+  const handles = [
+    Meteor.subscribe('todos.inList', id),
+    Meteor.subscribe('otherSub'),
+  ];
+  const loading = handles.some(handle => !handle.ready());
+  return {
+    loading,
+  };
+})(ListPage);
+```
+
 It's a good habit to name your container exactly like the component that it wraps, with the word “Container” tacked onto the end. This way, when you're attempting to track down issues in your code, it makes it much easier to locate the appropriate files/classes.
 
 The container component created by `withTracker` will reactively re-render the wrapped component in response to any changes to [reactive data sources](https://atmospherejs.com/meteor/tracker) accessed from inside the function provided to it.


### PR DESCRIPTION
Add documentation on how to handle properly multiple subscriptions using [`Array.some`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/some) and [`Array.every`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/every).

I've noticed a useless pattern across many codebases where devs would assign each handle to a variable, then may assign `handle.ready()` to another variable (ex: `const xIsReady = handle.ready()`), then they would check each of them inside a huge condition to compute the ready/loading state.

Using [`Array.some`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/some) and [`Array.every`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/every) simplify everything as we only have to add a `Meteor.subscribe` into the array and let him handle the ready state.