### PR TITLE
Prevent exporting Container as global variable

### DIFF
--- a/content/react.md
+++ b/content/react.md
@@ -215,7 +215,7 @@ ListPage.propTypes = {
 };
 ```
 
-Then we create a `ListPageContainer` container component which wraps it and provides a data source:
+Then we create a container component which wraps it and provides a data source:
 
 ```js
 import { Meteor } from 'meteor/meteor';
@@ -223,7 +223,7 @@ import { Lists } from '../../api/lists/lists.js';
 import { withTracker } from 'meteor/react-meteor-data';
 import ListPage from '../pages/ListPage.js';
 
-export default ListPageContainer = withTracker(({ id }) => {
+export default withTracker(({ id }) => {
   const todosHandle = Meteor.subscribe('todos.inList', id);
   const loading = !todosHandle.ready();
   const list = Lists.findOne(id);
@@ -237,7 +237,15 @@ export default ListPageContainer = withTracker(({ id }) => {
 })(ListPage);
 ```
 
-It's a good habit to name your container exactly like the component that it wraps, with the word “Container” tacked onto the end. This way, when you're attempting to track down issues in your code, it makes it much easier to locate the appropriate files/classes.
+It's a good habit to name your container exactly like the component that it wraps (ex: `ListPageContainer`), with the word “Container” tacked onto the end. This way, when you're attempting to track down issues in your code, it makes it much easier to locate the appropriate files/classes. To do this, you would have to assign the “Container” to a `const`, then `export default` the const:
+
+```js
+const ListPageContainer = withTracker(({ id }) => {
+  // ...
+})(ListPage);
+
+export default ListPageContainer;
+```
 
 The container component created by `withTracker` will reactively re-render the wrapped component in response to any changes to [reactive data sources](https://atmospherejs.com/meteor/tracker) accessed from inside the function provided to it.
 
@@ -294,7 +302,8 @@ const App = (props) => (
   </div>
 );
 
-export default AppContainer = withTracker(props => {
+// Will be known as AppContainer
+export default withTracker(props => {
   // props here will have `main`, passed from the router
   // anything we return from this function will be *added* to it
   return {

--- a/content/react.md
+++ b/content/react.md
@@ -223,7 +223,7 @@ import { Lists } from '../../api/lists/lists.js';
 import { withTracker } from 'meteor/react-meteor-data';
 import ListPage from '../pages/ListPage.js';
 
-export default withTracker(({ id }) => {
+const ListPageContainer = withTracker(({ id }) => {
   const todosHandle = Meteor.subscribe('todos.inList', id);
   const loading = !todosHandle.ready();
   const list = Lists.findOne(id);
@@ -235,17 +235,11 @@ export default withTracker(({ id }) => {
     todos: listExists ? list.todos().fetch() : [],
   };
 })(ListPage);
-```
-
-It's a good habit to name your container exactly like the component that it wraps (ex: `ListPageContainer`), with the word “Container” tacked onto the end. This way, when you're attempting to track down issues in your code, it makes it much easier to locate the appropriate files/classes. To do this, you would have to assign the “Container” to a `const`, then `export default` the const:
-
-```js
-const ListPageContainer = withTracker(({ id }) => {
-  // ...
-})(ListPage);
 
 export default ListPageContainer;
 ```
+
+It's a good habit to name your container exactly like the component that it wraps, with the word “Container” tacked onto the end (eg `ListPageContainer`). This way, when you're attempting to track down issues in your code, it makes it much easier to locate the appropriate files/classes.
 
 The container component created by `withTracker` will reactively re-render the wrapped component in response to any changes to [reactive data sources](https://atmospherejs.com/meteor/tracker) accessed from inside the function provided to it.
 
@@ -302,14 +296,15 @@ const App = (props) => (
   </div>
 );
 
-// Will be known as AppContainer
-export default withTracker(props => {
+const AppContainer = withTracker(props => {
   // props here will have `main`, passed from the router
   // anything we return from this function will be *added* to it
   return {
     user: Meteor.user(),
   };
 })(App);
+
+export default AppContainer
 ```
 
 <h3 id="using-react-router">React Router</h3>


### PR DESCRIPTION
I noticed an unwanted behavior across Meteor codebases that I've been able to track down here.

If we do the following, we do not simply name our container, we create a **global variable** that we export:

```js
export default ListPageContainer = withTracker(({ id }) => {
  // ...
})(ListPage);
```

The syntax below is not valid, we can't `export default` an inline initialized variable. As a side effect, we'll have `ListPageContainer` in our global scope.

We would have to..

Declare the const before using `export default` keyword:

```js
const ListPageContainer = withTracker(({ id }) => {
  // ...
})(ListPage);

export default ListPageContainer;
```

Or if they're in the same file, we can `export default` our base class, and `export` our container as an inline `const`.

```js
export default class ListPage extends Component {
  // ...
}

export const ListPageContainer = withTracker(({ id }) => {
  // ...
})(ListPage);
```

Then, we'll have to import like this:

```js
import ListPage, { ListPageContainer } from "...";
```

cc @abernix A serious unattended behavior that probably worth your eyes on. 👀 