### PR TITLE
Add missing closing H2 tag

### DIFF
--- a/content/vue.md
+++ b/content/vue.md
@@ -303,7 +303,7 @@ You should see:
 There may be better or alternative ways to do these things.  Please PR if you have improvements.
 
 
-<h2 id="style-guide">Meteor’s and Vue’s Style Guides and Structure
+<h2 id="style-guide">Meteor’s and Vue’s Style Guides and Structure</h2>
 
 Like code linting and style guides are tools for making code easier and more fun to work with.
 


### PR DESCRIPTION
The closing </h2> tag was omitted. This causes the Table of Contents and section to render incorrectly.

<!--
🙌 Thanks for making this PR 😃
-->

TODO:

- [ ] If this is a significant change, update [CHANGELOG.md](https://github.com/meteor/guide/blob/master/CHANGELOG.md)
- [ ] Use `<h2 id="foo">` instead of `## Foo` for headers
- [ ] Leave a blank line after each header
