### PR TITLE
Replace references to percolatestudio:migrations by npm mgdb-migrator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ title: Changelog
 order: 1001
 description: A log of significant changes to the Meteor Guide.
 ---
-
+- 2019/10/23 : updated `percolate:migrations` reference to maintained npm version `mgdb-migrator`
 - 2018/10/23: Added VueJS SSR Rendering for Meteor guide
 - 2018/10/14: Added VueJS Integration guide
 - 2017/10/28: Removed mention of `react-addons-pure-render-mixin` package from "Using Meteor's data system" section as it is no longer needed.


### PR DESCRIPTION
Since `mdgb-migrator` has been created from `percolatestudio:migrations` and seems more up to date and maintained, this PR proposes to replace the references to `percolatestudio:migrations` by the npm version