### PR TITLE
Fix #1017 by replacing error inducing code indentation with backticks

### DIFF
--- a/content/1.3-migration.md
+++ b/content/1.3-migration.md
@@ -9,9 +9,9 @@ discourseTopicId: 20190
 These are all the *breaking changes* -- that is changes that you absolutely have to worry about if you are updating your app from 1.2.x to 1.3. However, we recommend that you also consider the *recommended* changes listed in the other sections below.
 
  - Ensure that your project has a [`package.json`](https://docs.npmjs.com/files/package.json) file, which will be the foundation for npm package installs.  You can create this by running:
-
-       meteor npm init -y
-
+    ```
+    meteor npm init -y
+    ```
  - Files in a directory named `imports/` will no longer load eagerly. (You should probably rename such a directory as it is the basis of our new [module system](#modules)).
 
  - Files within your app named `*.test[s].*`, `*.app-test[s].*`, `*.spec[s].*` and `*.app-spec[s].*` will no longer load eagerly (you should probably rename such a file if it doesn't contain tests, as it will be eagerly loaded by our new [app testing modes](#testing)).

--- a/content/1.4-migration.md
+++ b/content/1.4-migration.md
@@ -12,9 +12,9 @@ These are all the *breaking changes* &mdash; that is, changes you absolutely hav
 <a name="babel-runtime-required"></a>
 
 The `babel-runtime` npm package is generally required as a dependency since the Meteor `babel-runtime` package no longer attempts to provide custom implementations of Babel helper functions. To install the `babel-runtime` npm, run the following command in any Meteor application:
-
-    meteor npm install --save babel-runtime
-
+```
+meteor npm install --save babel-runtime
+```
 New projects created with `meteor create <app-name>` will automatically have this package added to their `package.json`'s `dependencies`.
 
 <h3 id="binary-packages-require-build-toolchain">Binary Packages require a Build Toolchain</h3>

--- a/content/mobile.md
+++ b/content/mobile.md
@@ -101,9 +101,9 @@ A shortcut is to run `sudo xcodebuild -license accept` from the command line. (Y
 <h4>Enabling Xcode command line tools</h4>
 
 After installing Xcode from the Mac App Store, it is still necesssary to enable those tools in the terminal environment.  This can be accompilshed by running the following from the command prompt:
-
+```
     sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
-
+```
 <h3 id="installing-prerequisites-android">Android</h3>
 
 In order to build and run Android apps, you will need to:

--- a/site/package.json
+++ b/site/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "hexo": {
-    "version": "3.7.1"
+    "version": "3.9.0"
   },
   "devDependencies": {
     "chexo": "1.0.7",


### PR DESCRIPTION
I don't know why this started erroring, likely a dependency update.
Fixed by replacing indentation based code blocks with ``` ones which are semantically equivalent

Also updates `site/package.json` because hexo wants to update that field to match the version running, which also matches the dependencies list.