### PR TITLE
Fixed broken link to getting started guide

### DIFF
--- a/content/testing.md
+++ b/content/testing.md
@@ -806,7 +806,7 @@ Now we can run the tests with `meteor npm test`.
 
 <h3 id="using-circle-ci">CircleCI</h3>
 
-[CircleCI](https://circleci.com) is a great continuous integration service that allows us to run (possibly time consuming) tests on every push to a repository like GitHub. To use it with the commandline test we've defined above, we can follow their standard [getting started tutorial](https://circleci.com/docs/getting-started) and use a `circle.yml` file similar to this:
+[CircleCI](https://circleci.com) is a great continuous integration service that allows us to run (possibly time consuming) tests on every push to a repository like GitHub. To use it with the commandline test we've defined above, we can follow their standard [getting started tutorial](https://circleci.com/docs/2.0/getting-started/#section=getting-started) and use a `circle.yml` file similar to this:
 
 ```
 machine:


### PR DESCRIPTION
The link to the CircleCI Getting Started guide was broken so I've researched and corrected the link in this patch
correct link is: https://circleci.com/docs/2.0/getting-started/#section=getting-started