### PR TITLE
Add "React Native" section to guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ title: Changelog
 order: 1001
 description: A log of significant changes to the Meteor Guide.
 ---
+- 2020/04/26: Added "React Native" section to build, and renamed "Mobile" to "Cordova"
 - 2020/02/03: Added "Preventing unnecessary data retrieval" section to Accounts
 - 2018/10/23: Added VueJS SSR Rendering for Meteor guide
 - 2018/10/14: Added VueJS Integration guide

--- a/content/cordova.md
+++ b/content/cordova.md
@@ -1,5 +1,5 @@
 ---
-title: Mobile
+title: Cordova
 description: How to build mobile apps using Meteor's Cordova integration.
 discourseTopicId: 20195
 ---

--- a/content/react-native.md
+++ b/content/react-native.md
@@ -1,0 +1,53 @@
+---
+title: React Native
+description: How to integrate your React Native apps with Meteor
+---
+
+React Native has grown to be one of the most popular platforms for building native apps. You can easily integrate your React Native app with Meteor, using the same methods you would on a Meteor + React Web app. The integration supports most Meteor features, including Methods, Pub/Sub, and Password Accounts, and has the same usage as `react-meteor-data`.
+
+<h2 id="installation">Installation</h2>
+
+In your React Native app you need to install the meteor-react-native package.
+
+````
+npm install --save meteor-react-native
+````
+
+**Note: If your React Native app uses version 0.59 or lower, the meteor-react-native package contains breaking changes. Use [react-native-meteor](https://www.npmjs.com/package/react-native-meteor) instead.**
+
+<h2 id="usage">Basic Usage</h2>
+
+Import `Meteor`, `withTracker`, and `Mongo`:
+
+````
+import { Meteor, Mongo, withTracker } from 'meteor-react-native';
+````
+
+Connect to your Meteor Server:
+
+````
+Meteor.connect("wss://myapp.meteor.com");
+````
+
+Define your collections:
+
+````
+let Todos = new Mongo.Collection("todos");
+````
+
+Pass data to your component using withTracker:
+
+````
+let MyAppContainer = withTracker(() = {
+    
+    let myTodoTasks = Todos.find({completed:false}).fetch();
+    
+    return {
+        myTodoTasks
+    };
+    
+})(MyApp);
+````
+
+
+You can view the full API docs on the [meteor-react-native repo](https://github.com/TheRealNate/meteor-react-native/blob/master/docs/api.md)

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -37,7 +37,8 @@ sidebar_categories:
     - writing-atmosphere-packages
     - using-npm-packages
     - writing-npm-packages
-    - mobile
+    - cordova
+    - react-native    
     - build-tool
   Production:
     - security


### PR DESCRIPTION
- Add new "React Native" article which describes integrating React Native with Meteor using the `meteor-react-native` npm package.
- Rename "Mobile" to "Cordova"