### PR TITLE
Update vue.md

### DIFF
--- a/content/vue.md
+++ b/content/vue.md
@@ -16,6 +16,7 @@ Vue already has an excellent guide with many advanced topics already covered. So
 This documentation is purely focused on integrating it with Meteor.
 
 <h2 id="introduction">Introduction</h2>
+
 [Vue](https://vuejs.org/v2/guide/) (pronounced /vjuː/, like view) is a progressive framework for building user interfaces. 
 Unlike other monolithic frameworks, Vue is designed from the ground up to be incrementally adoptable. 
 The core library is focused on the view layer only, and is easy to pick up and integrate with other libraries or existing projects. On the other hand, Vue is also perfectly capable of powering sophisticated Single-Page Applications when used in combination with [modern tooling](https://vuejs.org/v2/guide/single-file-components.html) and [supporting libraries](https://github.com/vuejs/awesome-vue#components--libraries).


### PR DESCRIPTION
style tiny fix
Left a blank line after header to render link correctly


<!--
🙌 Thanks for making this PR 😃
-->

TODO:

- [ ] If this is a significant change, update [CHANGELOG.md](https://github.com/meteor/guide/blob/master/CHANGELOG.md)
- [ ] Use `<h2 id="foo">` instead of `## Foo` for headers
- [x] Leave a blank line after each header
