### PR TITLE
docs(deployment): removes mLab as suggested DBaaS

### DIFF
--- a/content/deployment.md
+++ b/content/deployment.md
@@ -205,7 +205,6 @@ When you deploy your Meteor server, you need a `MONGO_URL` that points to your M
 
 There are a variety of services out there, and we recommend that you select one of the below services depending on your requirements:
 
-* [mLab](https://www.mlab.com)
 * [Compose](https://www.compose.io)
 * [MongoDB Atlas](https://www.mongodb.com/cloud/atlas)
 


### PR DESCRIPTION
mLab got acquired by MongoDB and their customers are encouraged to migrate to MongoDB Atlas instead. Removing mLab makes sense, as their services are being sunset. MongoDB Atlas is already incorporated in the list of suggested database hosts, so this guides users to the service replacing mLab.

https://docs.mlab.com/mlab-to-atlas/

<!--
🙌 Thanks for making this PR 😃
-->

TODO:

- [x] If this is a significant change, update [CHANGELOG.md](https://github.com/meteor/guide/blob/master/CHANGELOG.md)
- [x] Use `<h2 id="foo">` instead of `## Foo` for headers
- [x] Leave a blank line after each header
