### PR TITLE
Small corrections in Hot Code Push and Cordova articles

### DIFF
--- a/content/cordova.md
+++ b/content/cordova.md
@@ -284,6 +284,8 @@ An important benefit of this is that while downloading may be slow over mobile c
 
 Downloading updates is done incrementally, so we only download assets that have actually changed (based on a content hash). In addition, if we haven't been able to download all changed assets in one go, because of a network failure or because the app was closed before we finished, we will reuse the ones that have already completed downloading the next time the app starts up or the network connection is restored.
 
+If Hot Code Push is not working reliably in your app, and this section doesn't help, see our [guide on diagnosing Hot Code Push issues](/hot-code-push).
+
 <h3 id="updating-production-apps">In production</h3>
 
 Hot code push greatly improves the development experience, but on mobile, it is also a really useful feature for production apps, because it allows you to quickly push updates to devices without having users update the app through the store and without going through a possibly lengthy review process to get your update accepted.

--- a/content/cordova.md
+++ b/content/cordova.md
@@ -315,8 +315,8 @@ Now your users' apps will continue receiving hot code pushes. However, they won'
 Another option is using the `METEOR_CORDOVA_COMPAT_VERSION_EXCLUDE` environment variable. If you were to do this:
 
 ```sh
-meteor add cordova-plugin-camera
-meteor add cordova-plugin-gyroscope
+meteor add cordova:cordova-plugin-camera@4.1.0
+meteor add cordova:cordova-plugin-gyroscope@0.1.4
 METEOR_CORDOVA_COMPAT_VERSION_EXCLUDE='cordova-plugin-camera,cordova-plugin-gyroscope' meteor run ios-device
 ```
 

--- a/content/hot-code-push.md
+++ b/content/hot-code-push.md
@@ -34,7 +34,7 @@ Meteor, Cordova and plugins cannot be updated through Hot Code Push. So Meteor b
 
 You can [override this behavior](/cordova.html#controlling-compatibility-version). Just make sure you deal with potentially incompatible versions in your JS instead.
 
-<h3 id="set-autoupdate-version">Set an AUTOUPDATE_VERSION</h3>
+<h3 id="set-autoupdate-version">Update your AUTOUPDATE_VERSION</h3>
 
 `AUTOUPDATE_VERSION` is an environment variable you can add to your `run` and `deploy` [commands](https://docs.meteor.com/commandline.html):
 
@@ -42,9 +42,7 @@ You can [override this behavior](/cordova.html#controlling-compatibility-version
 $ AUTOUPDATE_VERSION=abc meteor deploy example.com
 ```
 
-You can set a new one for every deploy to update all your mobile and web clients. Or keep the same one, when you want them to not update.
-
-If adding this variable this fixes your HCP issue, it means your server thinks the client code and assets didn’t actually change. You'll want to figure out why [WebApp.calculateClientHash](https://github.com/meteor/meteor/blob/devel/packages/webapp/webapp_server.js#L267) isn’t generating new hashes for your new code.
+If your app has an `AUTOUPDATE_VERSION` set, make sure you change its value when you want a deploy to update your clients.
 
 <h3 id="no-soft-update-in-cordova">Cordova doesn’t hot reload CSS separately</h3>
 
@@ -92,9 +90,9 @@ Error: Error downloading asset: /
   at <anonymous>:1:9
 ```
 
-This error from [cordova-plugin-meteor-webapp](https://github.com/meteor/cordova-plugin-meteor-webapp) may be caused by big files in the `public` folder. Downloading these can fail depending on connection speed, and available space on the device.
+This error from [cordova-plugin-meteor-webapp](https://github.com/meteor/cordova-plugin-meteor-webapp) may be caused by big files, often in the `public` folder. Downloading these can fail depending on connection speed, and available space on the device.
 
-You could run `$ du -a public | sort -n -r | head -n 20` to find the 20 biggest files and their sizes. Consider serving them from an external storage service or CDN instead. In this case, they are only downloaded when really needed, and can fail downloading without blocking HCP.
+You could run `$ du -a public | sort -n -r | head -n 20` to find the 20 biggest files and their sizes. Consider serving them from an external storage service or CDN instead. Then they are only downloaded when really needed, and can fail downloading without blocking HCP.
 
 <h3 id="locally">If it is only broken locally</h3>
 
@@ -150,7 +148,7 @@ Tracker.autorun(() => {
 ```js
 const { ready, inactive } = _.chain(Meteor)
   .get('default_connection._subscriptions', {})
-  .toPairs() // Reshape the thing
+  .toPairs()
   .map(1)
   .find({ name: 'meteor_autoupdate_clientVersions' })
   .pick(['inactive', 'ready']) // comment this to see all options


### PR DESCRIPTION
<!--
🙌 Thanks for making this PR 😃
-->

In the Hot Code Push guide ([which I wrote](https://github.com/meteor/guide/pull/1045)),

- A few small fixes and clarificationos
- Remove one paragraph that was more likely to confuse than help

In the Cordova guide,

- Add a link to the Hot Code Push guide
- Fix a code example that wasn't working

DONE (no significant changes, no new headers)

- [x] If this is a significant change, update [CHANGELOG.md](https://github.com/meteor/guide/blob/master/CHANGELOG.md)
- [x] Use `<h2 id="foo">` instead of `## Foo` for headers
- [x] Leave a blank line after each header

