### PR TITLE
Remove crosswalk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ title: Changelog
 order: 1001
 description: A log of significant changes to the Meteor Guide.
 ---
+- 2020/09/13: Removed the section about crosswalk from the Cordova guide
 - 2020/08/08: Added "Hot Code Push" guide
 - 2020/04/26: Added "React Native" section to build, and renamed "Mobile" to "Cordova"
 - 2020/02/03: Added "Preventing unnecessary data retrieval" section to Accounts

--- a/content/cordova.md
+++ b/content/cordova.md
@@ -56,7 +56,7 @@ Meteor uses WKWebView by default, on both iOS 8 and iOS 9. WKWebView is part of 
 
 <h4 id="what-environment-android">Android</h4>
 
-Android 5.0 also comes with a web view based on Chromium known as the [Android System Web View](https://play.google.com/store/apps/details?id=com.google.android.webview&hl=en), but a big improvement is that it can be automatically updated through the Play Store. This means updates to the web view happen more regularly and are independent of OS updates.
+Android 5.0 and above come with a web view based on Chromium known as the [Android System Web View](https://play.google.com/store/apps/details?id=com.google.android.webview&hl=en), which can be automatically updated through the Play Store. This means updates to the web view can happen regularly and are independent of OS updates.
 
 <h3 id="adding-platforms">Adding Cordova platforms</h3>
 

--- a/content/cordova.md
+++ b/content/cordova.md
@@ -56,16 +56,7 @@ Meteor uses WKWebView by default, on both iOS 8 and iOS 9. WKWebView is part of 
 
 <h4 id="what-environment-android">Android</h4>
 
-The web view situation on Android is a little more complicated. On older Android versions, the included web view is known to be rather slow and buggy. That improved somewhat with Android 4.4, which includes a web view based on Chromium, the open source project behind the Chrome browser.
-
 Android 5.0 also comes with a web view based on Chromium known as the [Android System Web View](https://play.google.com/store/apps/details?id=com.google.android.webview&hl=en), but a big improvement is that it can be automatically updated through the Play Store. This means updates to the web view happen more regularly and are independent of OS updates.
-
-This threatens to leave many older Android devices behind however, because they would be stuck on the web view included with the OS and are often unable to update to newer OS versions. Fortunately, the [Crosswalk plugin](https://crosswalk-project.org/documentation/cordova.html) allows you to embed Chromium in your app and use it instead of the web view that comes with the OS on any of the Android versions supported by Cordova (currently Android 4.0 or higher). Embedding Chromium means the size of your APK will grow by about 20MB, but the benefit is that you can rely on a consistent web view with considerably better performance and enhanced standards support.
-
-You can add the Crosswalk plugin to your app with `meteor add crosswalk`.
-> If you receive an error message trying to run the app on your device after adding or removing the Crosswalk plugin, you may have to remove the existing app from your device first.
-
-Important: The Crosswalk project is not maintained anymore. The last Crosswalk release was Crosswalk 23. Read more in this [announcement](https://crosswalk-project.org/blog/crosswalk-final-release.html)
 
 <h3 id="adding-platforms">Adding Cordova platforms</h3>
 

--- a/content/cordova.md
+++ b/content/cordova.md
@@ -642,7 +642,7 @@ From this point on, the process for building the app archive and submitting it t
 In order to build your app for Android, you will need to [configure your app](#configuring-your-app) with at least a version number, and the required set of app icons and launch screens.
 
 After running `meteor build` the generated APK will be copied from the `<build-output-directory>/android/project/build/outputs/apk/release` directory to `<build-output-directory>/android/release-unsigned.apk`.
-> If you have installed the [Crosswalk plugin](https://crosswalk-project.org/) you will need to manually copy the APK file `cp ~/build-output-directory/android/project/build/outputs/apk/android-armv7-release-unsigned.apk ~/build-output-directory/android/release-unsigned.apk`
+> If you have installed [Crosswalk](https://atmospherejs.com/meteor/crosswalk), you will need to manually copy the APK file `cp ~/build-output-directory/android/project/build/outputs/apk/android-armv7-release-unsigned.apk ~/build-output-directory/android/release-unsigned.apk`
 
 Before submitting the APK(s) to the Play Store, you will need to sign the APK and run [`zipalign`](http://developer.android.com/tools/help/zipalign.html) on it to optimize the archive.
 


### PR DESCRIPTION
<!--
🙌 Thanks for making this PR 😃
-->

As discussed here: https://github.com/meteor/guide/issues/1047

I removed the section about problems with web views in Android 4 and previous, and how crosswalk helps you solve them.

For those already using crosswalk, I decided to keep the crosswalk instructions in the "deploying to production" section. I only fixed the link.

TODO

- [x] If this is a significant change, update [CHANGELOG.md](https://github.com/meteor/guide/blob/master/CHANGELOG.md)
- [x] Use `<h2 id="foo">` instead of `## Foo` for headers
- [x] Leave a blank line after each header
