### PR TITLE
Update build-tool.md

### DIFF
--- a/content/build-tool.md
+++ b/content/build-tool.md
@@ -60,7 +60,7 @@ TypeScript can be installed with:
 
 ```sh
 meteor remove ecmascript
-meteor add barbatus:typescript
+meteor add adornis:typescript
 ```
 
 It is necessary to configure the TypeScript compiler with a `tsconfig.json` file.


### PR DESCRIPTION
barbatus typescript is noted to be deprecated on github; updated to adornis, as recommended by the deprecated package

<!--
🙌 Thanks for making this PR 😃
-->

TODO:

- [ ] If this is a significant change, update [CHANGELOG.md](https://github.com/meteor/guide/blob/master/CHANGELOG.md)
- [ ] Use `<h2 id="foo">` instead of `## Foo` for headers
- [ ] Leave a blank line after each header
