### PR TITLE
Remove obsolete section with dynamic imports

### DIFF
--- a/content/build-tool.md
+++ b/content/build-tool.md
@@ -113,12 +113,6 @@ If you want to add TypeScript from the point of project creation, as of Meteor 1
 meteor create --typescript name-of-my-new-typescript-app
 ```
 
-<h4 id="typescript-conditional-imports">Conditional imports</h4>
-
-TypeScript does not support nested `import` statements, therefore conditionally importing modules requires you to use the `require` statement (see [Using `require`](https://guide.meteor.com/structure.html#using-require)).
-
-To maintain type safety, you can take advantage of TypeScript's import elision and reference the types using the `typeof` keyword. See the [TypeScript handbook article](https://www.typescriptlang.org/docs/handbook/modules.html#optional-module-loading-and-other-advanced-loading-scenarios) for details or [this blog post](http://ideasintosoftware.com/typescript-conditional-imports/) for a concrete Meteor example.
-
 <h2 id="blaze-templates">Templates and HTML</h2>
 
 Since Meteor uses client-side rendering for your app's UI, all of your HTML code, UI components, and templates need to be compiled to JavaScript. There are a few options at your disposal to write your UI code.


### PR DESCRIPTION
Typescript now supports dynamic imports—and has for almost three years—so this section (which I added four years ago :) ) is misleading and should be removed.