### PR TITLE
2.4 migration guide

### DIFF
--- a/content/1.10-migration.md
+++ b/content/1.10-migration.md
@@ -1,0 +1,64 @@
+---
+title: Migrating to Meteor 1.10
+description: How to migrate your application to Meteor 1.10.
+---
+
+Most of the new features in Meteor 1.10 are either applied directly behind the scenes (in a backwards compatible manner) or are opt-in. For a complete breakdown of the changes, please refer to the [changelog](http://docs.meteor.com/changelog.html).
+
+The above being said, some breaking changes to note and migration steps for a bug that you might encounter.
+
+<h3 id="mongo-exit-62">Unexpected mongo exit code 62</h3>
+
+If you get `Unexpected mongo exit code 62. Restarting.` when starting your local
+MongoDB, you can either reset your project (`meteor reset`)
+(if you don't care about your local data)
+or you will need to update the feature compatibility version of your local MongoDB:
+
+    1. Downgrade your app to earlier version of Meteor `meteor update --release 1.9.2`
+    2. Start your application
+    3. While your application is running open a new terminal window, navigate to the
+       app directory and open `mongo` shell: `meteor mongo`
+    4. Use: `db.adminCommand({ getParameter: 1, featureCompatibilityVersion: 1 })` to
+       check the current feature compatibility.
+    5. If the returned version is less than 4.0 update like this:
+       `db.adminCommand({ setFeatureCompatibilityVersion: "4.2" })`
+    6. You can now stop your app and update to Meteor 1.10.
+
+    For more information about this, check out [MongoDB documentation](https://docs.mongodb.com/manual/release-notes/4.2-upgrade-standalone/).
+
+<h3 id="cordova-update">Cordova upgrade</h3>
+
+Cordova has been updated from version 7 to 9. We recommend that you test
+your features that are taking advantage of Cordova plugins to be sure
+they are still working as expected.
+
+<h3 id="WKWebViewOnly">WKWebViewOnly</h3>
+
+WKWebViewOnly is set by default now as true so if you are relying on
+UIWebView or plugins that are using UIWebView APIs you probably want to
+set it as false, you can do this by calling
+`App.setPreference('WKWebViewOnly', false);` in your mobile-config.js. But we
+don't recommend turning this into false because
+[Apple have said](https://developer.apple.com/news/?id=12232019b) they are
+going to reject apps using UIWebView.
+
+<h3 id="windows-32bit-drop">Windows 32-bit support dropped</h3>
+
+Because MongoDB since 3.4 no longer supports 32-bit Windows, Meteor 1.10 has
+also dropped support for 32-bit Windows. In other words, Meteor 1.10 supports
+64-bit Mac, Windows 64-bit, and Linux 64-bit.
+
+<h2 id="older-versions">Migrating from a version older than 1.9.3?</h2>
+
+If you're migrating from a version of Meteor older than Meteor 1.9.3, there may be important considerations not listed in this guide (which specifically covers 1.9.3 to 1.10). Please review the older migration guides for details:
+
+* [Migrating to Meteor 1.9.3](1.9.3-migration.html) (from 1.9)
+* [Migrating to Meteor 1.9](1.9-migration.html) (from 1.8.3)
+* [Migrating to Meteor 1.8.3](1.8.3-migration.html) (from 1.8.2)
+* [Migrating to Meteor 1.8.2](1.8.2-migration.html) (from 1.8)
+* [Migrating to Meteor 1.8](1.8-migration.html) (from 1.7)
+* [Migrating to Meteor 1.7](1.7-migration.html) (from 1.6)
+* [Migrating to Meteor 1.6](1.6-migration.html) (from 1.5)
+* [Migrating to Meteor 1.5](1.5-migration.html) (from 1.4)
+* [Migrating to Meteor 1.4](1.4-migration.html) (from 1.3)
+* [Migrating to Meteor 1.3](1.3-migration.html) (from 1.2)

--- a/content/1.10.2-migration.md
+++ b/content/1.10.2-migration.md
@@ -1,0 +1,44 @@
+---
+title: Migrating to Meteor 1.10.2
+description: How to migrate your application to Meteor 1.10.2.
+---
+
+Most of the new features in Meteor 1.10.2 are either applied directly behind the scenes (in a backwards compatible manner) or are opt-in. For a complete breakdown of the changes, please refer to the [changelog](http://docs.meteor.com/changelog.html).
+
+The above being said, there is a breaking change for those using the Flow syntax.
+
+<h3 id="flow-unsupported">Flow syntax not supported</h3>
+
+The `babel-compiler` package, used by both `ecmascript` and
+`typescript`, no longer supports stripping [Flow](https://flow.org/)
+type annotations by default, which may be a breaking change if your
+application (or Meteor package) relied on Flow syntax.
+
+If you still need Babel's Flow plugins, you can install them with npm
+and then enable them with a custom `.babelrc` file in your application's
+(or package's) root directory:
+
+```json
+{
+"plugins": [
+  "@babel/plugin-syntax-flow",
+  "@babel/plugin-transform-flow-strip-types"
+]
+}
+```
+
+<h2 id="older-versions">Migrating from a version older than 1.10?</h2>
+
+If you're migrating from a version of Meteor older than Meteor 1.10, there may be important considerations not listed in this guide (which specifically covers 1.10 to 1.10.2). Please review the older migration guides for details:
+
+* [Migrating to Meteor 1.10](1.10-migration.html) (from 1.9.3)
+* [Migrating to Meteor 1.9.3](1.9.3-migration.html) (from 1.9)
+* [Migrating to Meteor 1.9](1.9-migration.html) (from 1.8.3)
+* [Migrating to Meteor 1.8.3](1.8.3-migration.html) (from 1.8.2)
+* [Migrating to Meteor 1.8.2](1.8.2-migration.html) (from 1.8)
+* [Migrating to Meteor 1.8](1.8-migration.html) (from 1.7)
+* [Migrating to Meteor 1.7](1.7-migration.html) (from 1.6)
+* [Migrating to Meteor 1.6](1.6-migration.html) (from 1.5)
+* [Migrating to Meteor 1.5](1.5-migration.html) (from 1.4)
+* [Migrating to Meteor 1.4](1.4-migration.html) (from 1.3)
+* [Migrating to Meteor 1.3](1.3-migration.html) (from 1.2)

--- a/content/1.11-migration.md
+++ b/content/1.11-migration.md
@@ -1,0 +1,36 @@
+---
+title: Migrating to Meteor 1.11
+description: How to migrate your application to Meteor 1.11.
+---
+
+Most of the new features in Meteor 1.11 are either applied directly behind the scenes (in a backwards compatible manner) or are opt-in. For a complete breakdown of the changes, please refer to the [changelog](http://docs.meteor.com/changelog.html).
+
+The above being said, there some breaking changes to note and migration steps for a bug that you might encounter.
+
+<h3 id="eamil-dns">Email DNS lookup</h3>
+
+`email` package dependencies have been update and package version has been bumped to 2.0.0
+There is a potential breaking change as the underlying package started to use `dns.resolve()`
+instead of `dns.lookup()` which might be breaking on some environments.
+See [nodemailer changelog](https://github.com/nodemailer/nodemailer/blob/master/CHANGELOG.md) for more information.
+
+<h3 id="cordova-git-url">Cordova now working with Git urls</h3>
+
+Cordova add plugin is not working with plugin name in the git URL when the plugin id was different than the name in the config.xml.
+
+<h2 id="older-versions">Migrating from a version older than 1.10.2?</h2>
+
+If you're migrating from a version of Meteor older than Meteor 1.10.2, there may be important considerations not listed in this guide (which specifically covers 1.10.2 to 1.11). Please review the older migration guides for details:
+
+* [Migrating to Meteor 1.10.2](1.10.2-migration.html) (from 1.10)
+* [Migrating to Meteor 1.10](1.10-migration.html) (from 1.9.3)
+* [Migrating to Meteor 1.9.3](1.9.3-migration.html) (from 1.9)
+* [Migrating to Meteor 1.9](1.9-migration.html) (from 1.8.3)
+* [Migrating to Meteor 1.8.3](1.8.3-migration.html) (from 1.8.2)
+* [Migrating to Meteor 1.8.2](1.8.2-migration.html) (from 1.8)
+* [Migrating to Meteor 1.8](1.8-migration.html) (from 1.7)
+* [Migrating to Meteor 1.7](1.7-migration.html) (from 1.6)
+* [Migrating to Meteor 1.6](1.6-migration.html) (from 1.5)
+* [Migrating to Meteor 1.5](1.5-migration.html) (from 1.4)
+* [Migrating to Meteor 1.4](1.4-migration.html) (from 1.3)
+* [Migrating to Meteor 1.3](1.3-migration.html) (from 1.2)

--- a/content/1.12-migration.md
+++ b/content/1.12-migration.md
@@ -1,0 +1,42 @@
+---
+title: Migrating to Meteor 1.12
+description: How to migrate your application to Meteor 1.12.
+---
+
+Most of the new features in Meteor 1.12 are either applied directly behind the scenes (in a backwards compatible manner) or are opt-in. For a complete breakdown of the changes, please refer to the [changelog](http://docs.meteor.com/changelog.html).
+
+The above being said, there are some breaking changes to note.
+
+<h3 id="types-imports">Importing types</h3>
+
+When importing types in Typescript, you might need to use the "type" qualifier, like so:
+```js
+import { Point } from 'react-easy-crop/types';
+```
+to
+```ts
+import type { Point } from 'react-easy-crop/types';
+```
+Because now `emitDecoratorsMetadata` is enabled.
+
+<h3 id="typescript-upgrade">Typescript upgraded to 4.1.2</h3>
+
+Refer to typescript breaking changes before migrating your existing project, from 3.7.6 to 4.1.2: https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes
+
+<h2 id="older-versions">Migrating from a version older than 1.11?</h2>
+
+If you're migrating from a version of Meteor older than Meteor 1.11, there may be important considerations not listed in this guide (which specifically covers 1.11 to 1.12). Please review the older migration guides for details:
+
+* [Migrating to Meteor 1.11](1.11-migration.html) (from 1.10.2)
+* [Migrating to Meteor 1.10.2](1.10.2-migration.html) (from 1.10)
+* [Migrating to Meteor 1.10](1.10-migration.html) (from 1.9.3)
+* [Migrating to Meteor 1.9.3](1.9.3-migration.html) (from 1.9)
+* [Migrating to Meteor 1.9](1.9-migration.html) (from 1.8.3)
+* [Migrating to Meteor 1.8.3](1.8.3-migration.html) (from 1.8.2)
+* [Migrating to Meteor 1.8.2](1.8.2-migration.html) (from 1.8)
+* [Migrating to Meteor 1.8](1.8-migration.html) (from 1.7)
+* [Migrating to Meteor 1.7](1.7-migration.html) (from 1.6)
+* [Migrating to Meteor 1.6](1.6-migration.html) (from 1.5)
+* [Migrating to Meteor 1.5](1.5-migration.html) (from 1.4)
+* [Migrating to Meteor 1.4](1.4-migration.html) (from 1.3)
+* [Migrating to Meteor 1.3](1.3-migration.html) (from 1.2)

--- a/content/1.8-migration.md
+++ b/content/1.8-migration.md
@@ -1,0 +1,69 @@
+---
+title: Migrating to Meteor 1.8
+description: How to migrate your application to Meteor 1.8.
+---
+
+Most of the new features in Meteor 1.8 are either applied directly behind the scenes (in a backwards compatible manner) or are opt-in. For a complete breakdown of the changes, please refer to the [changelog](http://docs.meteor.com/changelog.html).
+
+The above being said, there is one required migration step and few things that you should note.
+
+<h3 id="babel-update">Update the `@babel/runtime`</h3>
+
+Update the `@babel/runtime` npm package to version 7.0.0 or later:
+
+```sh
+meteor npm install @babel/runtime@latest
+```
+
+<h3 id="legacy-bundle">web.browser.legacy</h3>
+
+Meteor 1.7 introduced a new client bundle called `web.browser.legacy` in
+addition to the `web.browser` (modern) and `web.cordova` bundles.
+Naturally, this extra bundle increased client (re)build times. Since
+developers spend most of their time testing the modern bundle in
+development, and the legacy bundle mostly provides a safe fallback in
+production, Meteor 1.8 cleverly postpones building the legacy bundle
+until just after the development server restarts, so that development
+can continue as soon as the modern bundle has finished building. Since
+the legacy build happens during a time when the build process would
+otherwise be completely idle, the impact of the legacy build on server
+performance is minimal. Nevertheless, the legacy bundle still gets
+rebuilt regularly, so any legacy build errors will be surfaced in a
+timely fashion, and legacy clients can test the new legacy bundle by
+waiting a bit longer than modern clients. Applications using the
+`autoupdate` or `hot-code-push` packages will reload modern and legacy
+clients independently, once each new bundle becomes available.
+
+<h3 id="forced-package-version">Overriding package version</h3>
+
+The `.meteor/packages` file supports a new syntax for overriding
+problematic version constraints from packages you do not control.
+
+If a package version constraint in `.meteor/packages` ends with a `!`
+character, any other (non-`!`) constraints on that package elsewhere in
+the application will be _weakened_ to allow any version greater than or
+equal to the constraint, even if the major/minor versions do not match.
+
+For example, using both CoffeeScript 2 and `practicalmeteor:mocha` used
+to be impossible (or at least very difficult) because of this
+[`api.versionsFrom("1.3")`](https://github.com/practicalmeteor/meteor-mocha/blob/3a2658070a920f8846df48bb8d8c7b678b8c6870/package.js#L28)
+statement, which unfortunately constrained the `coffeescript` package to
+version 1.x. In Meteor 1.8, if you want to update `coffeescript` to
+2.x, you can relax the `practicalmeteor:mocha` constraint by putting
+  ```
+  coffeescript@2.2.1_1! # note the !
+  ```
+in your `.meteor/packages` file. The `coffeescript` version still needs
+to be at least 1.x, so that `practicalmeteor:mocha` can count on that
+minimum. However, `practicalmeteor:mocha` will no longer constrain the
+major version of `coffeescript`, so `coffeescript@2.2.1_1` will work.
+
+<h2 id="older-versions">Migrating from a version older than 1.7?</h2>
+
+If you're migrating from a version of Meteor older than Meteor 1.7, there may be important considerations not listed in this guide (which specifically covers 1.7 to 1.8). Please review the older migration guides for details:
+
+* [Migrating to Meteor 1.7](1.7-migration.html) (from 1.6)
+* [Migrating to Meteor 1.6](1.6-migration.html) (from 1.5)
+* [Migrating to Meteor 1.5](1.5-migration.html) (from 1.4)
+* [Migrating to Meteor 1.4](1.4-migration.html) (from 1.3)
+* [Migrating to Meteor 1.3](1.3-migration.html) (from 1.2)

--- a/content/1.8.2-migration.md
+++ b/content/1.8.2-migration.md
@@ -1,0 +1,59 @@
+---
+title: Migrating to Meteor 1.8.2
+description: How to migrate your application to Meteor 1.8.2.
+---
+
+Most of the new features in Meteor 1.8.2 are either applied directly behind the scenes (in a backwards compatible manner) or are opt-in. For a complete breakdown of the changes, please refer to the [changelog](http://docs.meteor.com/changelog.html).
+
+The above being said, there are required migration steps that you should perform for this release to run smoothly.
+
+<h3 id="babel-update">Update the `@babel/runtime`</h3>
+
+Be sure to update the `@babel/runtime` npm package to its latest version
+(currently 7.7.2):
+
+```sh
+meteor npm install @babel/runtime@latest
+```
+
+<h3 id="meteor-node-stubs">Meteor Node Stubs</h3>
+
+New Meteor applications now depend on `meteor-node-stubs@1.0.0`, so it
+may be a good idea to update to the same major version:
+
+```sh
+meteor npm install meteor-node-stubs@next
+```
+
+<h3 id="packages-republish">Packages should be re-published</h3>
+
+If you are the author of any Meteor packages, and you encounter errors
+when using those packages in a Meteor 1.8.2 application (for example,
+`module.watch` being undefined), we recommend that you bump the minor
+version of your package and republish it using Meteor 1.8.2, so
+Meteor 1.8.2 applications will automatically use the new version of the
+package, as compiled by Meteor 1.8.2:
+
+```sh
+cd path/to/your/package
+# Add api.versionsFrom("1.8.2") to Package.onUse in package.js...
+meteor --release 1.8.2 publish
+```
+
+This may not be necessary for all packages, especially those that have
+been recently republished using Meteor 1.8.1, or local packages in the
+`packages/` directory (which are always recompiled from source).
+However, republishing packages is a general solution to a wide variety
+of package versioning and compilation problems, and package authors can
+make their users' lives easier by handling these issues proactively.
+
+<h2 id="older-versions">Migrating from a version older than 1.8?</h2>
+
+If you're migrating from a version of Meteor older than Meteor 1.8, there may be important considerations not listed in this guide (which specifically covers 1.8 to 1.8.2). Please review the older migration guides for details:
+
+* [Migrating to Meteor 1.8](1.8-migration.html) (from 1.7)
+* [Migrating to Meteor 1.7](1.7-migration.html) (from 1.6)
+* [Migrating to Meteor 1.6](1.6-migration.html) (from 1.5)
+* [Migrating to Meteor 1.5](1.5-migration.html) (from 1.4)
+* [Migrating to Meteor 1.4](1.4-migration.html) (from 1.3)
+* [Migrating to Meteor 1.3](1.3-migration.html) (from 1.2)

--- a/content/1.8.3-migration.md
+++ b/content/1.8.3-migration.md
@@ -1,0 +1,35 @@
+---
+title: Migrating to Meteor 1.8.3
+description: How to migrate your application to Meteor 1.8.3.
+---
+
+Most of the new features in Meteor 1.8.3 are either applied directly behind the scenes (in a backwards compatible manner) or are opt-in. For a complete breakdown of the changes, please refer to the [changelog](http://docs.meteor.com/changelog.html).
+
+The above being said, there is a required migration steps for those that use Blaze or jQuery.
+
+<h3 id="npm-jquery">Use NPM jQuery</h3>
+
+If your application uses `blaze-html-templates`, the Meteor `jquery`
+package will be automatically installed in your `.meteor/packages` file
+when you update to Meteor 1.8.3. However, this new version of the Meteor
+`jquery` package no longer bundles its own copy of the `jquery` npm
+implementation, so you may need to install `jquery` from npm by running
+
+```sh
+meteor npm i jquery
+```
+
+in your application directory. Symptoms of not installing jquery include
+a blank browser window, with helpful error messages in the console.
+
+<h2 id="older-versions">Migrating from a version older than 1.8.2?</h2>
+
+If you're migrating from a version of Meteor older than Meteor 1.8.2, there may be important considerations not listed in this guide (which specifically covers 1.8.2 to 1.8.3). Please review the older migration guides for details:
+
+* [Migrating to Meteor 1.8.2](1.8.2-migration.html) (from 1.8)
+* [Migrating to Meteor 1.8](1.8-migration.html) (from 1.7)
+* [Migrating to Meteor 1.7](1.7-migration.html) (from 1.6)
+* [Migrating to Meteor 1.6](1.6-migration.html) (from 1.5)
+* [Migrating to Meteor 1.5](1.5-migration.html) (from 1.4)
+* [Migrating to Meteor 1.4](1.4-migration.html) (from 1.3)
+* [Migrating to Meteor 1.3](1.3-migration.html) (from 1.2)

--- a/content/1.9-migration.md
+++ b/content/1.9-migration.md
@@ -1,0 +1,27 @@
+---
+title: Migrating to Meteor 1.9
+description: How to migrate your application to Meteor 1.9.
+---
+
+Most of the new features in Meteor 1.9 are either applied directly behind the scenes (in a backwards compatible manner) or are opt-in. For a complete breakdown of the changes, please refer to the [changelog](http://docs.meteor.com/changelog.html).
+
+The above being said, there is a major breaking change that you should note.
+
+<h3 id="no-32bit-version">Discontinuation of 32-bit Unix versions</h3>
+
+Because Node.js 12 no longer supports 32-bit Linux, Meteor 1.9 has also
+dropped support for 32-bit Linux. In other words, Meteor 1.9 supports
+64-bit Mac, Windows, and Linux, as well as 32-bit Windows.
+
+<h2 id="older-versions">Migrating from a version older than 1.8.3?</h2>
+
+If you're migrating from a version of Meteor older than Meteor 1.8.3, there may be important considerations not listed in this guide (which specifically covers 1.8.3 to 1.9). Please review the older migration guides for details:
+
+* [Migrating to Meteor 1.8.3](1.8.3-migration.html) (from 1.8.2)
+* [Migrating to Meteor 1.8.2](1.8.2-migration.html) (from 1.8)
+* [Migrating to Meteor 1.8](1.8-migration.html) (from 1.7)
+* [Migrating to Meteor 1.7](1.7-migration.html) (from 1.6)
+* [Migrating to Meteor 1.6](1.6-migration.html) (from 1.5)
+* [Migrating to Meteor 1.5](1.5-migration.html) (from 1.4)
+* [Migrating to Meteor 1.4](1.4-migration.html) (from 1.3)
+* [Migrating to Meteor 1.3](1.3-migration.html) (from 1.2)

--- a/content/1.9.3-migration.md
+++ b/content/1.9.3-migration.md
@@ -1,0 +1,26 @@
+---
+title: Migrating to Meteor 1.9.3
+description: How to migrate your application to Meteor 1.9.3.
+---
+
+Most of the new features in Meteor 1.9.3 are either applied directly behind the scenes (in a backwards compatible manner) or are opt-in. For a complete breakdown of the changes, please refer to the [changelog](http://docs.meteor.com/changelog.html).
+
+The above being said, there is a fix to an error that you might get to note.
+
+<h3 id="mongo-retry-writers">MongoError unsupported retryable writes</h3>
+
+If you get the error `MongoError: This MongoDB deployment does not support retryable writes. Please add retryWrites=false to your connection string.`, append `retryWrites=false` to your MongoDB connection string.
+
+<h2 id="older-versions">Migrating from a version older than 1.9?</h2>
+
+If you're migrating from a version of Meteor older than Meteor 1.9, there may be important considerations not listed in this guide (which specifically covers 1.9 to 1.9.3). Please review the older migration guides for details:
+
+* [Migrating to Meteor 1.8.2](1.9-migration.html) (from 1.8.3)
+* [Migrating to Meteor 1.8.3](1.8.3-migration.html) (from 1.8.2)
+* [Migrating to Meteor 1.8.2](1.8.2-migration.html) (from 1.8)
+* [Migrating to Meteor 1.8](1.8-migration.html) (from 1.7)
+* [Migrating to Meteor 1.7](1.7-migration.html) (from 1.6)
+* [Migrating to Meteor 1.6](1.6-migration.html) (from 1.5)
+* [Migrating to Meteor 1.5](1.5-migration.html) (from 1.4)
+* [Migrating to Meteor 1.4](1.4-migration.html) (from 1.3)
+* [Migrating to Meteor 1.3](1.3-migration.html) (from 1.2)

--- a/content/2.0-migration.md
+++ b/content/2.0-migration.md
@@ -1,0 +1,37 @@
+---
+title: Migrating to Meteor 2.0
+description: How to migrate your application to Meteor 2.0.
+---
+
+Most of the new features in Meteor 2.0 are either applied directly behind the scenes (in a backwards compatible manner) or are opt-in. For a complete breakdown of the changes, please refer to the [changelog](http://docs.meteor.com/changelog.html).
+
+The above being said, there is a thing to note.
+
+<h3 id="hmr">Hot Module Replacement</h3>
+
+Updates the javascript modules in a running app that were modified during a rebuild. Reduces the feedback cycle while developing so you can view and test changes quicker (it even updates the app before the build has finished). Enabled by adding the `hot-module-replacement` package to an app. React components are automatically updated by default using React Fast Refresh. Integrations with other libraries and view layers can be provided by third party packages. Support for Blaze is coming soon. This first version supports app code in the modern web architecture. ([docs](https://guide.meteor.com/build-tool.html#hot-module-replacement)) [#11117](https://github.com/meteor/meteor/pull/11117)
+
+<h3 id="free-cloud">Free tier for Meteor Cloud is back</h3>
+
+Free deploy on [Cloud](https://www.meteor.com/cloud): Deploy for free to Cloud with one command: `meteor deploy myapp.meteorapp.com --free`. ([docs](https://docs.meteor.com/commandline.html#meteordeploy))
+
+Deploy including MongoDB on [Cloud](https://www.meteor.com/cloud): Deploy including MongoDB in a shared instance for free to Cloud with one command: `meteor deploy myapp.meteorapp.com --free --mongo`. ([docs](https://docs.meteor.com/commandline.html#meteordeploy))
+
+<h2 id="older-versions">Migrating from a version older than 1.12?</h2>
+
+If you're migrating from a version of Meteor older than Meteor 1.12, there may be important considerations not listed in this guide (which specifically covers 1.12 to 2.0). Please review the older migration guides for details:
+
+* [Migrating to Meteor 1.12](1.12-migration.html) (from 1.11)
+* [Migrating to Meteor 1.11](1.11-migration.html) (from 1.10.2)
+* [Migrating to Meteor 1.10.2](1.10.2-migration.html) (from 1.10)
+* [Migrating to Meteor 1.10](1.10-migration.html) (from 1.9.3)
+* [Migrating to Meteor 1.9.3](1.9.3-migration.html) (from 1.9)
+* [Migrating to Meteor 1.9](1.9-migration.html) (from 1.8.3)
+* [Migrating to Meteor 1.8.3](1.8.3-migration.html) (from 1.8.2)
+* [Migrating to Meteor 1.8.2](1.8.2-migration.html) (from 1.8)
+* [Migrating to Meteor 1.8](1.8-migration.html) (from 1.7)
+* [Migrating to Meteor 1.7](1.7-migration.html) (from 1.6)
+* [Migrating to Meteor 1.6](1.6-migration.html) (from 1.5)
+* [Migrating to Meteor 1.5](1.5-migration.html) (from 1.4)
+* [Migrating to Meteor 1.4](1.4-migration.html) (from 1.3)
+* [Migrating to Meteor 1.3](1.3-migration.html) (from 1.2)

--- a/content/2.2-migration.md
+++ b/content/2.2-migration.md
@@ -1,0 +1,44 @@
+---
+title: Migrating to Meteor 2.2
+description: How to migrate your application to Meteor 2.2.
+---
+
+Most of the new features in Meteor 2.2 are either applied directly behind the scenes (in a backwards compatible manner) or are opt-in. For a complete breakdown of the changes, please refer to the [changelog](http://docs.meteor.com/changelog.html).
+
+The above being said, there are a few breaking changes that you might need to apply migration for.
+
+<h3 id="mongodb-windows">Running MongoDB on Windows</h3>
+
+`meteor-tool` has been updated and you might need to install the new Visual C++ Redistributable for Visual Studio 2019 to run MongoDB 4.4.4 on Windows. [read more](https://docs.meteor.com/windows.html)
+
+<h3 id="mongodb-useUnifiedTopology">MongoDB `useUnifiedTopology`</h3>
+
+`mongo` package is now using `useUnifiedTopology` as `true` by default otherwise the new driver was producing a warning (see details below). It's important to test your app with this change.
+
+<h3 id="cordova-10">Cordova 10</h3>
+
+`cordova` plugins and main libraries were updated from 9 to 10. It's important to test your app with these changes.
+
+<h3 id="typescript-4.2.2">Typescript 4.2.2</h3>
+
+`typescript` was updated to 4.2.2, make sure your read the [breaking changes](https://devblogs.microsoft.com/typescript/announcing-typescript-4-2/#breaking-changes).
+
+<h2 id="older-versions">Migrating from a version older than 2.0?</h2>
+
+If you're migrating from a version of Meteor older than Meteor 2.0, there may be important considerations not listed in this guide (which specifically covers 2.0 to 2.2). Please review the older migration guides for details:
+
+* [Migrating to Meteor 2.0](2.0-migration.html) (from 1.12)
+* [Migrating to Meteor 1.12](1.12-migration.html) (from 1.11)
+* [Migrating to Meteor 1.11](1.11-migration.html) (from 1.10.2)
+* [Migrating to Meteor 1.10.2](1.10.2-migration.html) (from 1.10)
+* [Migrating to Meteor 1.10](1.10-migration.html) (from 1.9.3)
+* [Migrating to Meteor 1.9.3](1.9.3-migration.html) (from 1.9)
+* [Migrating to Meteor 1.9](1.9-migration.html) (from 1.8.3)
+* [Migrating to Meteor 1.8.3](1.8.3-migration.html) (from 1.8.2)
+* [Migrating to Meteor 1.8.2](1.8.2-migration.html) (from 1.8)
+* [Migrating to Meteor 1.8](1.8-migration.html) (from 1.7)
+* [Migrating to Meteor 1.7](1.7-migration.html) (from 1.6)
+* [Migrating to Meteor 1.6](1.6-migration.html) (from 1.5)
+* [Migrating to Meteor 1.5](1.5-migration.html) (from 1.4)
+* [Migrating to Meteor 1.4](1.4-migration.html) (from 1.3)
+* [Migrating to Meteor 1.3](1.3-migration.html) (from 1.2)

--- a/content/2.3-migration.md
+++ b/content/2.3-migration.md
@@ -1,0 +1,91 @@
+---
+title: Migrating to Meteor 2.3
+description: How to migrate your application to Meteor 2.3.
+---
+
+Most of the new features in Meteor 2.3 are either applied directly behind the scenes (in a backwards compatible manner) or are opt-in. For a complete breakdown of the changes, please refer to the [changelog](http://docs.meteor.com/changelog.html).
+
+The above being said, there are a few breaking changes that you might need to apply migration for.
+
+<h3 id="node-14">Node.js v14</h3>
+
+As Node.js version was upgraded to a new major version we recommend that you review if your npm dependencies are compatible with Node.js 14.
+
+- If we receive reports from breaking changes we are going to list them here but so far we are not aware of any.
+- We recommend that you read Node.js [release notes](https://nodejs.org/en/blog/release/v14.0.0/) though.
+- We recommend that you remove your `node_modules` folder (`rm -rf node_modules`) and run `meteor npm i` to be sure you compile all the binary dependencies again using the new Node.js version.
+- Maybe you also want to recreate your lock file.
+- If you get an error try `meteor reset` which will clear caches, beware that this will also remove your local DB for your app.
+
+<h3 id="packages-deprecated-flag">`deprecated` option for packages</h3>
+
+In `Package.description`, there is a new `deprecated` option. If set to `true` it will inform user when installing that the package has been deprecated. Additionally you can provide a string that will be displayed, where you can direct the users where to go next.
+
+All official packages that have been deprecated have now the deprecated flag and will inform you about that if you install or update them.
+
+<h3 id="removed-deprecated-package-methods">Removal of deprecated package API</h3>
+
+Old API for packages definitions has been removed. The old underscore method names (`Package.on_use`, `Package.on_test`, `Package._transitional_registerBuildPlugin` and `api.add_files`) have been removed and will no longer work, please use the camel case method names (e.g. `api.addFiles()`).
+
+<h3 id="accounts-2.0">Accounts 2.0</h3>
+
+* `accounts-base@2.0.0`
+    - Deprecated backward compatibility function `logoutOtherClients` has been removed.
+
+* `accounts-password@2.0.0`
+    - Deprecated backward compatibility functionality for `SRP` passwords from pre-Meteor 1.0 days has been removed.
+    - Enroll account workflow has been separated from reset password workflow (the enrollment token records are now stored in a separate db field `services.password.enroll`).
+
+* `oauth@2.0.0`
+    - Removed deprecated `OAuth.initiateLogin` and other functionality like the addition of `?close` in return URI for deprecated OAuth flow pre Meteor 1.0
+
+If you are maintaining a package that depends on one of the accounts packages which had a major version bump you will either need to set the new version manually or set `api.versionsFrom('2.3')`.
+You can also have it reference its current version and 2.3 like this: `api.versionsFrom(['1.12', '2.3'])`, for specific package it can be like this: `api.use('accounts-base@1.0.1 || 2.0.0')`.
+
+<h3 id="http-2">HTTP v2</h3>
+
+Internally `http` package has replaced the use of http for [fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API), should still work as previous version, but edge cases might be different. This is to aid you in transition to fetch. Note that this means that the `npmRequestOptions` parameter to `HTTP.call` has been removed, as `request` is no longer used internally. You should migrate to the use of `fetch`. You can install polyfill package via:
+
+```sh
+meteor add fetch
+```
+
+<h3 id="removal-of-deprecated-api">Removal of deprecated APIs</h3>
+
+In addition to the above mentioned removal of deprecated package API, other long deprecated APIs have been removed and will no longer work.
+
+* Removed deprecated `mobile-port` flag
+* Removed deprecated `raw` name from `isobuild`
+* `ddp-client@2.5.0`
+    - Removed deprecated backward compatibility method names for Meteor before 1.0
+* `ddp-server@2.4.0`
+    - Removed deprecated backward compatibility method names for Meteor before 1.0
+* `meteor-base@1.5.0`
+    - Removed `livedata` dependency which was there for packages build for 0.9.0
+* `minimongo@1.7.0`
+    - Removed the `rewind` method that was noop for compatibility with Meteor 0.8.1
+* `mongo@1.12.0`
+    - Removed the `rewind` method that was noop for compatibility with Meteor 0.8.1
+* `socket-stream-client@0.4.0`
+    - Remove IE8 checks
+
+<h2 id="older-versions">Migrating from a version older than 2.2?</h2>
+
+If you're migrating from a version of Meteor older than Meteor 2.2, there may be important considerations not listed in this guide (which specifically covers 2.2 to 2.3). Please review the older migration guides for details:
+
+* [Migrating to Meteor 2.2](2.2-migration.html) (from 2.0)
+* [Migrating to Meteor 2.0](2.0-migration.html) (from 1.12)
+* [Migrating to Meteor 1.12](1.12-migration.html) (from 1.11)
+* [Migrating to Meteor 1.11](1.11-migration.html) (from 1.10.2)
+* [Migrating to Meteor 1.10.2](1.10.2-migration.html) (from 1.10)
+* [Migrating to Meteor 1.10](1.10-migration.html) (from 1.9.3)
+* [Migrating to Meteor 1.9.3](1.9.3-migration.html) (from 1.9)
+* [Migrating to Meteor 1.9](1.9-migration.html) (from 1.8.3)
+* [Migrating to Meteor 1.8.3](1.8.3-migration.html) (from 1.8.2)
+* [Migrating to Meteor 1.8.2](1.8.2-migration.html) (from 1.8)
+* [Migrating to Meteor 1.8](1.8-migration.html) (from 1.7)
+* [Migrating to Meteor 1.7](1.7-migration.html) (from 1.6)
+* [Migrating to Meteor 1.6](1.6-migration.html) (from 1.5)
+* [Migrating to Meteor 1.5](1.5-migration.html) (from 1.4)
+* [Migrating to Meteor 1.4](1.4-migration.html) (from 1.3)
+* [Migrating to Meteor 1.3](1.3-migration.html) (from 1.2)

--- a/content/2.4-migration.md
+++ b/content/2.4-migration.md
@@ -28,9 +28,21 @@ The `email` package had a feature update. You can now override the sending funct
 
 <h2 id="older-versions">Migrating from a version older than 2.3?</h2>
 
-If you're migrating from a version of Meteor older than Meteor 2.3, there may be important considerations not listed in this guide (which specifically covers 1.6 to 1.7). Please review the older migration guides for details:
+If you're migrating from a version of Meteor older than Meteor 2.3, there may be important considerations not listed in this guide (which specifically covers 2.2 to 2.3). Please review the older migration guides for details:
 
-* [Migrating to Meteor 1.6](1.7-migration.html) (from 1.6)
+* [Migrating to Meteor 2.3](2.3-migration.html) (from 2.2)
+* [Migrating to Meteor 2.2](2.2-migration.html) (from 2.0)
+* [Migrating to Meteor 2.0](2.0-migration.html) (from 1.12)
+* [Migrating to Meteor 1.12](1.12-migration.html) (from 1.11)
+* [Migrating to Meteor 1.11](1.11-migration.html) (from 1.10.2)
+* [Migrating to Meteor 1.10.2](1.10.2-migration.html) (from 1.10)
+* [Migrating to Meteor 1.10](1.10-migration.html) (from 1.9.3)
+* [Migrating to Meteor 1.9.3](1.9.3-migration.html) (from 1.9)
+* [Migrating to Meteor 1.9](1.9-migration.html) (from 1.8.3)
+* [Migrating to Meteor 1.8.3](1.8.3-migration.html) (from 1.8.2)
+* [Migrating to Meteor 1.8.2](1.8.2-migration.html) (from 1.8)
+* [Migrating to Meteor 1.8](1.8-migration.html) (from 1.7)
+* [Migrating to Meteor 1.7](1.7-migration.html) (from 1.6)
 * [Migrating to Meteor 1.6](1.6-migration.html) (from 1.5)
 * [Migrating to Meteor 1.5](1.5-migration.html) (from 1.4)
 * [Migrating to Meteor 1.4](1.4-migration.html) (from 1.3)

--- a/content/2.4-migration.md
+++ b/content/2.4-migration.md
@@ -1,0 +1,37 @@
+---
+title: Migrating to Meteor 2.4
+description: How to migrate your application to Meteor 2.4.
+---
+
+Most of the new features in Meteor 2.4 are either applied directly behind the scenes (in a backwards compatible manner) or are opt-in. For a complete breakdown of the changes, please refer to the [changelog](http://docs.meteor.com/changelog.html).
+
+The above being said, there are a few items that you should implement to have easier time in the future.
+
+<h3 id="createIndex">createIndex</h3>
+
+Previously undocumented `_ensureIndex` has been aligned with MongoDB breaking change in naming and is now usable as `createIndex`. Use of `_ensureIndex` is now deprecated and will throw a warning in development for you.
+
+<h3 id="email22">Email 2.2</h3>
+
+The `email` package had a feature update. You can now override the sending functionality completely with `Email.customTransport` or if you are using [known services](https://nodemailer.com/smtp/well-known/) you can now ditch the `MAIL_URL` environment variable and set it in your `settings.json` file, like so:
+```json
+{
+  "packages": {
+    "email": {
+      "service": "Mailgun",
+      "user": "postmaster@meteor.com",
+      "password": "superDuperPassword"
+    }
+  }
+}
+```
+
+<h2 id="older-versions">Migrating from a version older than 2.3?</h2>
+
+If you're migrating from a version of Meteor older than Meteor 2.3, there may be important considerations not listed in this guide (which specifically covers 1.6 to 1.7). Please review the older migration guides for details:
+
+* [Migrating to Meteor 1.6](1.7-migration.html) (from 1.6)
+* [Migrating to Meteor 1.6](1.6-migration.html) (from 1.5)
+* [Migrating to Meteor 1.5](1.5-migration.html) (from 1.4)
+* [Migrating to Meteor 1.4](1.4-migration.html) (from 1.3)
+* [Migrating to Meteor 1.3](1.3-migration.html) (from 1.2)

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -30,7 +30,7 @@ sidebar_categories:
     - index
     - code-style
     - structure
-    - 1.7-migration
+    - 2.4-migration
   Data:
     - collections
     - data-loading


### PR DESCRIPTION
In preparations for 2.4 release here is a quick migration guide as they were done until v1.7. I will look into creating ones for the missing versions as well to have guide complete in the future (maybe in this PR if I can manage it before it gets merged, but they will have to be backported to the old versions).